### PR TITLE
[codex] Remove unshipped config versioning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Turnwire v2 reads one owner-only JSON file. It never loads repository config or
+Turnwire reads one owner-only JSON file. It never loads repository config or
 `.env` files.
 
 Default locations:
@@ -16,7 +16,6 @@ Global `--config PATH` and `--data-dir PATH` overrides precede the command.
 
 ```json
 {
-  "version": 2,
   "identity": {
     "name": "work",
     "peers": [

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -37,8 +37,8 @@ func TestResolveReleaseOverridesTakePrecedence(t *testing.T) {
 		},
 	}
 
-	got := resolve("v2.0.0", "release-revision", "release-time", build, true)
-	if got.Version != "v2.0.0" || got.Commit != "release-revision" || got.BuildTime != "release-time" ||
+	got := resolve("v9.0.0", "release-revision", "release-time", build, true)
+	if got.Version != "v9.0.0" || got.Commit != "release-revision" || got.BuildTime != "release-time" ||
 		got.Modified == nil || *got.Modified {
 		t.Fatalf("resolve() = %#v", got)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openclaw/turnwire/internal/identity"
 )
 
-func TestInitCreatesV2IdentityAndPeerAdd(t *testing.T) {
+func TestInitCreatesIdentityAndPeerAdd(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "config", "config.json")
 	dataDir := filepath.Join(root, "state")
@@ -33,7 +33,7 @@ func TestInitCreatesV2IdentityAndPeerAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Version != 2 || cfg.Identity.Name != "work" || cfg.Guard.Model != "gpt-5.5-2026-04-23" || cfg.Guard.PromptCacheRetention != "24h" {
+	if cfg.Identity.Name != "work" || cfg.Guard.Model != "gpt-5.5-2026-04-23" || cfg.Guard.PromptCacheRetention != "24h" {
 		t.Fatalf("config=%#v", cfg)
 	}
 	publicKey, _, err := ed25519.GenerateKey(rand.Reader)

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -249,7 +249,7 @@ func runDoctor(ctx context.Context, args []string, opts options, stdout io.Write
 		}
 	}
 	cfg, loadErr := config.Load(opts.configPath)
-	add("config", loadErr, "valid v2 configuration")
+	add("config", loadErr, "valid configuration")
 	if loadErr == nil {
 		auditDir, resolveErr := resolveAuditDir(cfg, opts.dataDir)
 		add("audit_path", resolveErr, "resolved")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	configVersion                = 2
 	defaultEndpoint              = "https://api.openai.com/v1/responses"
 	defaultModel                 = "gpt-5.4-2026-03-05"
 	defaultMaxMessageBytes       = 16 * 1024
@@ -37,7 +36,6 @@ const (
 
 // Config is the complete Turnwire configuration.
 type Config struct {
-	Version  int            `json:"version"`
 	Identity IdentityConfig `json:"identity"`
 	Guard    GuardConfig    `json:"guard"`
 	Limits   LimitsConfig   `json:"limits"`
@@ -326,9 +324,6 @@ func DefaultDataDir() string {
 
 // Validate rejects unsafe endpoints and invalid resource limits.
 func (c Config) Validate() error {
-	if c.Version != configVersion {
-		return errors.New("config.version must be 2")
-	}
 	if !validName(c.Identity.Name) {
 		return errors.New("config.identity.name must use 1-64 ASCII letters, digits, dot, underscore, colon, or hyphen")
 	}
@@ -485,7 +480,6 @@ func validName(value string) bool {
 
 func defaultConfig() Config {
 	return Config{
-		Version:  configVersion,
 		Identity: IdentityConfig{Name: "local", Peers: []PeerConfig{}},
 		Guard: GuardConfig{
 			API:                  "responses",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,7 +4,9 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -13,7 +15,7 @@ func TestDefaultIsPinnedFailClosedOpenAIGuard(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Version != 2 || cfg.Guard.API != "responses" || cfg.Guard.Model != "gpt-5.4-2026-03-05" {
+	if cfg.Guard.API != "responses" || cfg.Guard.Model != "gpt-5.4-2026-03-05" {
 		t.Fatalf("default guard = %#v", cfg.Guard)
 	}
 	if cfg.Guard.PromptCacheRetention != "in_memory" || !cfg.Guard.AllowRemote {
@@ -71,6 +73,13 @@ func TestWriteLoadRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config", "config.json")
 	if err := Write(path, cfg, false); err != nil {
 		t.Fatal(err)
+	}
+	encoded, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), `"version"`) {
+		t.Fatalf("config contains a redundant format version: %s", encoded)
 	}
 	loaded, err := Load(path)
 	if err != nil {

--- a/internal/mcpserver/request_limit.go
+++ b/internal/mcpserver/request_limit.go
@@ -171,7 +171,7 @@ func (s *requestLimitedStream) admitFrame(frame []byte) ([]byte, []*jsonrpc.Resp
 		for _, message := range messages {
 			request, isRequest := message.(*jsonrpc.Request)
 			if isRequest && !request.IsCall() {
-				// The legacy MCP batch implementation waits for one response per
+				// The MCP batch implementation waits for one response per
 				// element, but notifications intentionally produce no response.
 				// Reject the complete frame before reserving call or non-call state.
 				return nil, nil, errBatchContainsNotification


### PR DESCRIPTION
## What changed

- remove the redundant top-level config format version field
- remove matching validation, defaults, CLI wording, tests, and documentation
- remove the remaining legacy wording and unrelated v2-shaped test fixture
- verify generated configuration contains no format version marker

## Why

The rebuilt architecture has not shipped. It should define one clean configuration format rather than carrying migration or compatibility framing for an unreleased predecessor.

## Impact

`turnwire init` now writes the final strict configuration shape directly. Unknown fields still fail closed, so there is no compatibility or migration path to maintain.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/turnwire`
- `actionlint .github/workflows/ci.yml`
- repository search confirms no v2, legacy, migration, responder, or Chat Completions residue
- autoreview clean with no accepted or actionable findings
