### PR TITLE
[codex] Harden production deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            cgo: "0"
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+            cgo: "0"
+          - runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+            cgo: "1"
+          - runner: macos-15
+            goos: darwin
+            goarch: arm64
+            cgo: "1"
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.25.x"
+          cache: true
+      - name: Build archive and SBOM
+        env:
+          CGO_ENABLED: ${{ matrix.cgo }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          package="turnwire_${version}_${GOOS}_${GOARCH}"
+          mkdir -p "dist/${package}"
+          go build -trimpath \
+            -ldflags "-s -w -X github.com/openclaw/turnwire/internal/buildinfo.Version=${version} -X github.com/openclaw/turnwire/internal/buildinfo.Commit=${GITHUB_SHA} -X github.com/openclaw/turnwire/internal/buildinfo.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o "dist/${package}/turnwire" ./cmd/turnwire
+          cp README.md LICENSE "dist/${package}/"
+          go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 \
+            mod -json -output "dist/${package}/turnwire.cdx.json"
+          tar -C dist -czf "dist/${package}.tar.gz" "${package}"
+          rm -rf "dist/${package}"
+      - uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: dist/*.tar.gz
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: turnwire-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: turnwire-*
+          path: dist
+          merge-multiple: true
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum -- ./*.tar.gz > checksums.txt
+          cd ..
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "Turnwire $GITHUB_REF_NAME" \
+            --notes-file CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Rebuild Turnwire as a signed peer mailbox with outbound and inbound GPT-5.4/GPT-5.5 guards, deterministic secret blocking, local hash-bound approvals, delivery acknowledgements, and bilateral audit receipts.
 - Add Ed25519 endpoint identities, trusted-peer configuration, OpenAI request evidence, signed audit checkpoints, and practical Secure MCP Tunnel deployment guidance.
 - Harden the channel with exact returned-model pinning, single-classification verdicts, request and model-call budgets, structured-only byte-bounded MCP output, and JSON-RPC batch rejection.
+- Encrypt audit text at rest, persist fail-closed request/model budgets across restarts, bind measured deployments into signed checkpoints, and add dual-signed identity rotation, revocation, peer removal, and redacted audit exports.
+- Add hardened systemd/launchd tunnel service examples and a tag-only release pipeline producing checksummed archives, CycloneDX SBOMs, and GitHub build-provenance attestations.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ work agent / OpenAI                                      personal agent / OpenAI
         |          signed envelope -- agent ------->                 |
         |                 <---- signed acknowledgement               |
         v                                                           v
- work audit.jsonl                                       personal audit.jsonl
+ encrypted work audit                                  encrypted personal audit
 ```
 
 1. `send_message` records the proposal locally, runs deterministic secret/DLP
@@ -70,13 +70,15 @@ Tunnel is transport, not generic host-to-host networking.
 - Endpoints trust only configured peer public keys. Envelopes and delivery
   acknowledgements are Ed25519 signed.
 - Exact text, decisions, policy/model, OpenAI response and `x-request-id`, peer
-  identities, hashes, and receipts enter a synced hash-chained local log.
-- Signed audit checkpoints can be independently stored to detect later
-  whole-log replacement or truncation.
+  identities, hashes, and receipts enter a synced, AES-GCM-encrypted,
+  hash-chained local log.
+- Every service start records the executable, build, config, policy, peer set,
+  public key, and declared deployment identity. Signed checkpoints bind that
+  deployment digest to the current audit head.
 - MCP emits one structured result, rejects JSON-RPC batches, and caps every
   input frame and output frame. Inbox reads stop at a fixed encoded-byte cap.
-- Per-process request and guard-call budgets bound request floods and model
-  spend. Exhaustion fails closed; counters reset when the process restarts.
+- Fsynced request, raw-frame, and guard-call budgets survive restarts and clock
+  rollback. Exhaustion or unreadable accounting fails closed.
 
 For strongest OpenAI-side controls, use a dedicated API project approved for
 Zero Data Retention. `store: false` alone does not remove default abuse-
@@ -97,16 +99,16 @@ Work machine:
 
 ```bash
 go build -o ./bin/turnwire ./cmd/turnwire
-./bin/turnwire init --identity work
-./bin/turnwire identity
+./bin/turnwire init --identity work --deployment-id turnwire-work
+./bin/turnwire identity show
 ```
 
 Personal machine:
 
 ```bash
 go build -o ./bin/turnwire ./cmd/turnwire
-./bin/turnwire init --identity personal
-./bin/turnwire identity
+./bin/turnwire init --identity personal --deployment-id turnwire-personal
+./bin/turnwire identity show
 ```
 
 Exchange only the printed public keys, then pin each peer:
@@ -181,12 +183,15 @@ Audit commands:
 turnwire log list [--type TYPE] [--limit N] [--json]
 turnwire log show ID [--json]
 turnwire log verify [--json]
+turnwire log export --output AUDIT-METADATA.jsonl
 turnwire checkpoint
 ```
 
-Store periodic checkpoints outside the endpoint. Reconcile message IDs, hashes,
-signed acknowledgements, model/request IDs, and available OpenAI custom-app
-invocation logs.
+The export omits message text and model explanations, retains reconciliation
+metadata and chain hashes, and ends with a signed checkpoint. Copy exports and
+periodic checkpoints to immutable storage outside the endpoint. Reconcile
+message IDs, hashes, signed acknowledgements, model/request IDs, deployment
+digests, and available OpenAI custom-app invocation logs.
 
 ## Important limits
 
@@ -197,12 +202,15 @@ invocation logs.
   leakage.
 - Tunnel authorization controls the app path. Stdio does not expose a verified
   individual human caller identity; logs identify endpoint and peer.
-- A host administrator can replace binary, keys, policy, approvals, or log.
+- A host administrator can replace binary, keys, policy, approvals, log, or the
+  local audit-encryption key. External checkpoints and exports make later
+  replacement detectable; full-disk encryption still matters.
 - The agent carries released envelopes; Turnwire does not directly connect
   hosts.
 - Text only. Attachments and arbitrary host access remain out of scope.
 
-Read the [threat model](docs/threat-model.md) and
+Read the [deployment and operations runbook](docs/deployment.md),
+[threat model](docs/threat-model.md), and
 [configuration reference](docs/configuration.md) before deployment.
 
 ## Development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,9 @@ Global `--config PATH` and `--data-dir PATH` overrides precede the command.
       }
     ]
   },
+  "deployment": {
+    "id": "turnwire-work"
+  },
   "guard": {
     "api": "responses",
     "endpoint": "https://api.openai.com/v1/responses",
@@ -54,14 +57,28 @@ Unknown fields rejected.
 
 `identity.name` is the signed endpoint address. `turnwire init` generates
 `identity.ed25519` inside owner-only state. The private key never appears in
-config or CLI output. `turnwire identity` prints only the public key.
+config or CLI output. `turnwire identity show` prints only the public key.
 
 Each peer binds an allowed name to a raw-base64 Ed25519 public key. Duplicate
 names, self-peers, malformed keys, and unconfigured destinations fail closed.
 Add peers with `turnwire peer add NAME PUBLIC_KEY`.
 
+`turnwire identity rotate --force --output PATH` writes a transition signed by
+both old and new keys, then replaces the local key. Transfer that JSON out of
+band and run `turnwire peer rotate NAME ROTATION_FILE` on every peer. `turnwire identity
+revoke --force --output PATH` writes a signed certificate/checkpoint bundle and
+destroys the local key;
+remove the peer pin with `turnwire peer remove --force NAME`.
+
 Changing the identity name while reusing a private key changes the signed
 logical identity. Treat that as key management; update both peers explicitly.
+
+## Deployment identity
+
+`deployment.id` is the operator-declared tunnel/custom-app identity. It enters
+every startup attestation and signed checkpoint. Set it to a stable deployment
+identifier that matches the OpenAI-side tunnel/app inventory; it is evidence,
+not a remote proof that OpenAI associated the correct tunnel.
 
 ## Guard
 
@@ -125,8 +142,9 @@ Retrying reruns deterministic and model guards. Approval can override only
 - `max_guard_calls_per_hour`: combined outbound and inbound model calls;
   default 120, maximum 1000.
 
-Budgets are process-local sliding windows and reset on restart. Budget
-exhaustion fails closed. MCP additionally rejects JSON-RPC batches, emits only
+Budgets are fixed-window counters persisted and fsynced before admission. They
+survive restart; clock rollback does not replenish them. Corrupt or unwritable
+accounting fails closed. MCP additionally rejects JSON-RPC batches, emits only
 structured tool results, caps each output frame, and stops `list_messages`
 before its encoded result exceeds the fixed protocol ceiling.
 
@@ -136,11 +154,18 @@ data fail closed.
 
 ## Storage
 
-Config, state, identity keys, approvals, and `audit.jsonl` must be current-user
+Config, state, identity keys, approvals, budget counters, `audit.key`, and
+`audit.jsonl` must be current-user
 owned without group/other access or granting ACLs. Final symlinks rejected.
-Components traversed through held, no-follow descriptors. Audit entries are
-appended and synced before release, acceptance, or acknowledgement returns.
+Components traversed through held, no-follow descriptors. Audit text is
+AES-256-GCM encrypted before it enters `audit.jsonl`; hashes and metadata remain
+available for verification. The key is a separate owner-only state file, not a
+substitute for full-disk encryption or a hardware-backed secret store. Audit
+entries are appended and synced before release, acceptance, or acknowledgement
+returns.
 
-The log is append-only and SHA-256 hash chained; it does not rotate. Stop the
-service, archive complete state plus final signed checkpoint, then select a
-fresh owner-only directory before quota exhaustion.
+The log is append-only and SHA-256 hash chained; deleting or truncating it would
+also remove replay and delivery state. Do not rotate it destructively. Export
+redacted signed metadata periodically, retain the full encrypted state for the
+endpoint's lifetime, monitor quota, and decommission into a new identity/state
+directory before exhaustion. See the deployment runbook.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,106 @@
+# Deployment and operations
+
+## Recommended shape
+
+Run one endpoint per trust domain under a dedicated OS account. Use full-disk
+encryption, one dedicated OpenAI API project, one Secure MCP Tunnel/custom app,
+one Turnwire identity/state directory, and one narrowly associated workspace.
+The tunnel client is the supervised process and spawns `turnwire serve`; no
+Turnwire TCP listener or inbound firewall rule exists.
+
+Start with manual envelope relay. Automate only after the work administrator
+has approved the personal/work association, OpenAI retention settings are
+appropriate for the data class, tunnel `Read`/`Use`/`Manage` roles are split,
+and both sides agree on checkpoint/export reconciliation.
+
+## Install and verify
+
+Release archives contain the binary, license, and CycloneDX SBOM. Verify before
+installation:
+
+```bash
+sha256sum -c checksums.txt
+gh attestation verify turnwire_VERSION_OS_ARCH.tar.gz --repo openclaw/turnwire
+```
+
+Initialize with a deployment ID that matches the tunnel/app inventory:
+
+```bash
+turnwire init --identity work --deployment-id turnwire-work
+turnwire identity show
+turnwire peer add personal PERSONAL_PUBLIC_KEY
+turnwire doctor --probe
+turnwire checkpoint > initial-checkpoint.json
+```
+
+Store API credentials in the platform secret manager. Do not put secrets in
+arguments, the JSON config, service definition, or tunnel profile committed to
+source control. Prefer short-lived workload credentials where the OpenAI-side
+deployment supports them.
+
+Use `packaging/systemd/turnwire-tunnel.service` or the launchd example as a
+starting point. Adjust absolute paths, profile name, OS account, state path,
+and secret injection locally. Run `tunnel-client doctor --profile turnwire
+--explain` before enabling supervision.
+
+## Audit and retention
+
+The encrypted audit chain is authoritative protocol state, including replay
+bindings. Never truncate or delete old entries while retaining the identity.
+Monitor `max_audit_bytes`; move to a fresh identity/state directory before the
+quota is reached.
+
+At a fixed interval and after configuration, binary, policy, peer, or tunnel
+changes:
+
+```bash
+turnwire checkpoint > checkpoint.json
+turnwire log export --output audit-metadata-$(date -u +%Y%m%dT%H%M%SZ).jsonl
+```
+
+Copy both to append-only/WORM storage controlled by the corresponding domain.
+The export excludes message text and model explanations, includes selected
+reconciliation metadata, and ends with a signed checkpoint. Reconcile the two
+endpoint ledgers plus available OpenAI tunnel metadata, app invocation/auth,
+and organization audit exports. OpenAI logs complement rather than duplicate
+Turnwire's message ledger.
+
+## Key rotation
+
+Stop the tunnel service first; the exclusive audit lock makes concurrent local
+maintenance fail.
+
+```bash
+turnwire identity rotate --force --output work-rotation.json
+```
+
+Move the transition through an independently authenticated path. On every peer:
+
+```bash
+turnwire peer rotate work work-rotation.json
+turnwire doctor --probe
+turnwire checkpoint > post-rotation-checkpoint.json
+```
+
+The transition is signed by both old and new keys. Do not resume the tunnel
+until every expected peer has updated its pin.
+
+## Kill switch
+
+For suspected disclosure or unauthorized tunnel use:
+
+1. Disable the custom app/tunnel association and revoke its OpenAI runtime
+   credential.
+2. Stop and disable the local tunnel service.
+3. On the opposite endpoint, run `turnwire peer remove --force NAME`.
+4. On the affected endpoint, run `turnwire checkpoint` and `turnwire log export
+   --output final-audit-metadata.jsonl`; store both externally.
+5. Run `turnwire identity revoke --force --output revocation.json`. The output
+   bundles the signed revocation with a checkpoint covering its prepared audit
+   event. Preserve it, encrypted state, and relevant OpenAI audit records.
+6. Rebuild from a reviewed release into a fresh state directory, new identity,
+   new tunnel/app, and new runtime credential. Reassociate only after review.
+
+Self-signed revocation is evidence, not remote enforcement. Removing the peer
+pin, disabling the OpenAI association, and revoking runtime credentials are the
+enforcement steps.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -79,7 +79,10 @@ source independently verifies and logs that acknowledgement.
 - JSON-RPC batches rejected; successful tools return one structured result
   without a duplicate text serialization.
 - Synced canonical hash-chain events before externally visible transitions.
-- Signed checkpoints for independent anchoring.
+- Startup measurement of binary, build, config, policy, peers, identity, and
+  deployment ID; signed checkpoints bind the measurement to the audit head.
+- AES-256-GCM audit text encryption and redacted signed metadata exports.
+- Restart-durable, fsynced request, raw-frame, and model-call budgets.
 - Public MCP errors omit provider URLs, env names, paths, backend details.
 
 ## OpenAI boundary
@@ -110,15 +113,18 @@ reconciliation but are not a mirrored Turnwire ledger.
 - The agent carries envelope JSON. Turnwire does not directly connect hosts.
 - Work-to-personal app association can violate policy even when Turnwire works.
   Administrative approval is external.
-- Plaintext remains in owner-only audit and pending files. Disk encryption,
-  backup controls, retention, and secure deletion are deployment duties.
-- A compromised endpoint/key can sign malicious envelopes. Key revocation is
-  currently manual peer removal/config replacement.
-- Checkpoints prove endpoint-key possession, not uncompromised host or human
-  authorship.
+- Plaintext remains in process memory and pending approval records. The audit
+  log is encrypted, but its key is on the same host; disk encryption, backup
+  controls, retention, and secure deletion remain deployment duties.
+- A compromised endpoint/key can sign malicious envelopes. Dual-signed key
+  rotation, signed local revocation, and peer removal are explicit operator
+  actions; there is no online certificate authority.
+- Checkpoints prove endpoint-key possession and bind operator-measured bytes;
+  they do not prove an uncompromised host, a genuine remote tunnel association,
+  or human authorship.
 - Availability depends on OpenAI, tunnel, guard API, clocks, disk, endpoints.
-- Request and model-call budgets are in-memory and reset on process restart;
-  enforce project-level OpenAI budgets independently.
+- Local budgets survive restart, but enforce project-level OpenAI budgets and
+  rate limits independently as a second control.
 - Windows fails closed until owner-only DACL validation exists.
 
 ## Deployment requirements
@@ -131,4 +137,4 @@ reconciliation but are not a mirrored Turnwire ledger.
 - Periodic checkpoint storage in both administrative domains.
 - Reconcile release, acceptance, acknowledgement, local heads, guard request
   IDs, and available OpenAI logs.
-- Document key rotation, peer removal, archival, incident response, revocation.
+- Follow the checked-in key rotation, export, retention, and kill-switch runbook.

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -1,0 +1,89 @@
+// Package attestation measures the executable and security configuration used
+// by one Turnwire process.
+package attestation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/openclaw/turnwire/internal/buildinfo"
+	"github.com/openclaw/turnwire/internal/config"
+)
+
+// Record contains non-secret deployment evidence. Digest is stable for the
+// same binary and configuration and is safe to place in audit metadata.
+type Record struct {
+	DeploymentID     string `json:"deployment_id"`
+	Identity         string `json:"identity"`
+	PublicKey        string `json:"public_key"`
+	Version          string `json:"version"`
+	Commit           string `json:"commit"`
+	Modified         *bool  `json:"modified,omitempty"`
+	ExecutableSHA256 string `json:"executable_sha256"`
+	ConfigSHA256     string `json:"config_sha256"`
+	PolicySHA256     string `json:"policy_sha256"`
+	PeerSetSHA256    string `json:"peer_set_sha256"`
+	Digest           string `json:"digest"`
+}
+
+type peer struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+// Measure hashes the running executable, complete validated config, policy,
+// pinned peer set, identity, and build metadata.
+func Measure(cfg config.Config, publicKey string) (Record, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return Record{}, fmt.Errorf("locate executable: %w", err)
+	}
+	file, err := os.Open(executable)
+	if err != nil {
+		return Record{}, fmt.Errorf("open executable: %w", err)
+	}
+	executableHash := sha256.New()
+	_, copyErr := io.Copy(executableHash, file)
+	closeErr := file.Close()
+	if copyErr != nil || closeErr != nil {
+		return Record{}, fmt.Errorf("hash executable: %w", errors.Join(copyErr, closeErr))
+	}
+	configJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return Record{}, fmt.Errorf("encode config attestation: %w", err)
+	}
+	peers := make([]peer, 0, len(cfg.Identity.Peers))
+	for _, configured := range cfg.Identity.Peers {
+		peers = append(peers, peer{Name: configured.Name, PublicKey: configured.PublicKey})
+	}
+	sort.Slice(peers, func(i, j int) bool { return peers[i].Name < peers[j].Name })
+	peerJSON, err := json.Marshal(peers)
+	if err != nil {
+		return Record{}, err
+	}
+	info := buildinfo.Current()
+	record := Record{
+		DeploymentID: cfg.Deployment.ID, Identity: cfg.Identity.Name, PublicKey: publicKey,
+		Version: info.Version, Commit: info.Commit, Modified: info.Modified,
+		ExecutableSHA256: hex.EncodeToString(executableHash.Sum(nil)),
+		ConfigSHA256:     hash(configJSON), PolicySHA256: hash([]byte(cfg.Guard.Policy)),
+		PeerSetSHA256: hash(peerJSON),
+	}
+	canonical, err := json.Marshal(record)
+	if err != nil {
+		return Record{}, err
+	}
+	record.Digest = hash(canonical)
+	return record, nil
+}
+
+func hash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -4,7 +4,11 @@ package audit
 import (
 	"bufio"
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -19,11 +23,13 @@ import (
 	"unicode/utf8"
 
 	"github.com/openclaw/turnwire/internal/owneronly"
+	"github.com/openclaw/turnwire/internal/securestore"
 )
 
 const (
 	// FileName is the fixed file name used inside an audit directory.
-	FileName = "audit.jsonl"
+	FileName    = "audit.jsonl"
+	keyFileName = "audit.key"
 	// DefaultMaxBytes bounds the audit log when callers do not select a
 	// deployment-specific quota.
 	DefaultMaxBytes int64 = 256 << 20
@@ -86,6 +92,31 @@ type Entry struct {
 	EntryHash      string            `json:"entry_hash"`
 }
 
+// storedEntry is the only on-disk audit representation. Sensitive fields are
+// never serialized in plaintext; the entry hash is authenticated as AES-GCM
+// associated data and still binds the decrypted payload and chain metadata.
+type storedEntry struct {
+	Seq               uint64 `json:"seq"`
+	Timestamp         string `json:"timestamp"`
+	PayloadCiphertext string `json:"payload_ciphertext"`
+	PayloadNonce      string `json:"payload_nonce"`
+	PreviousHash      string `json:"previous_hash"`
+	EntryHash         string `json:"entry_hash"`
+}
+
+type storedPayload struct {
+	EventID        string            `json:"event_id"`
+	ExchangeID     string            `json:"exchange_id"`
+	RequestID      string            `json:"request_id"`
+	ConversationID string            `json:"conversation_id"`
+	Type           string            `json:"type"`
+	Status         string            `json:"status"`
+	ErrorCode      string            `json:"error_code"`
+	Text           string            `json:"text"`
+	TextSHA256     string            `json:"text_sha256"`
+	Details        map[string]string `json:"details,omitempty"`
+}
+
 // EntryReference identifies one verified entry in the append-only log without
 // retaining its text in memory. References are valid for the lifetime of the
 // log: successful appends never move existing bytes.
@@ -125,6 +156,7 @@ type Log struct {
 	maxBytes      int64
 	failed        error
 	io            auditIO
+	cipher        cipher.AEAD
 }
 
 // Open creates or opens an audit directory, enforces restrictive permissions,
@@ -168,7 +200,7 @@ func openWithQuotaAndIO(dir string, maxBytes int64, ioOps auditIO) (*Log, error)
 	}()
 
 	path := filepath.Join(dir, FileName)
-	file, _, err := openAuditFile(directory, true, true)
+	file, fileCreated, err := openAuditFile(directory, true, true)
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +212,14 @@ func openWithQuotaAndIO(dir string, maxBytes int64, ioOps auditIO) (*Log, error)
 		_ = unlockFile(file)
 		_ = file.Close()
 		return nil, openErr
+	}
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return closeOnError(fmt.Errorf("inspect audit file: %w", err))
+	}
+	aead, err := loadAuditCipher(dir, fileCreated || fileInfo.Size() == 0)
+	if err != nil {
+		return closeOnError(fmt.Errorf("load audit encryption key: %w", err))
 	}
 	// Flush both the file metadata and its directory entry before any append can
 	// be reported durable. This also completes recovery after a prior interrupted
@@ -202,7 +242,7 @@ func openWithQuotaAndIO(dir string, maxBytes int64, ioOps auditIO) (*Log, error)
 	}
 	directoryOpen = false
 
-	summary, err := scanAndVerify(file, nil)
+	summary, err := scanAndVerify(file, aead, nil)
 	if err != nil {
 		return closeOnError(fmt.Errorf("verify audit log: %w", err))
 	}
@@ -215,8 +255,34 @@ func openWithQuotaAndIO(dir string, maxBytes int64, ioOps auditIO) (*Log, error)
 		size:          summary.size,
 		maxBytes:      maxBytes,
 		io:            ioOps,
+		cipher:        aead,
 	}
 	return log, nil
+}
+
+func loadAuditCipher(dir string, create bool) (cipher.AEAD, error) {
+	store, err := securestore.Open(dir, create, "audit key directory")
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	key, err := store.Read(keyFileName)
+	if errors.Is(err, os.ErrNotExist) && create {
+		key = make([]byte, 32)
+		if _, err := rand.Read(key); err != nil {
+			return nil, fmt.Errorf("generate audit key: %w", err)
+		}
+		if err := store.Create(keyFileName, key); err != nil {
+			return nil, fmt.Errorf("store audit key: %w", err)
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errors.New("audit encryption key has an invalid size")
+	}
+	return cipher.NewGCM(block)
 }
 
 func secureStorageSupported() bool {
@@ -475,7 +541,11 @@ func (l *Log) AppendWithReference(event Event) (Entry, EntryReference, error) {
 		return Entry{}, EntryReference{}, err
 	}
 	entry.EntryHash = entryHash
-	line, err := json.Marshal(entry)
+	stored, err := encryptEntry(l.cipher, entry)
+	if err != nil {
+		return Entry{}, EntryReference{}, err
+	}
+	line, err := json.Marshal(stored)
 	if err != nil {
 		return Entry{}, EntryReference{}, fmt.Errorf("encode audit entry: %w", err)
 	}
@@ -532,7 +602,7 @@ func (l *Log) ReadAll() ([]Entry, error) {
 	if err := l.readyLocked(); err != nil {
 		return nil, err
 	}
-	return readAndVerify(l.file)
+	return readAndVerify(l.file, l.cipher)
 }
 
 // Scan verifies the complete chain and calls visit once for each entry while
@@ -559,7 +629,7 @@ func (l *Log) ScanWithReferences(visit func(Entry, EntryReference) error) error 
 	if visit == nil {
 		return errors.New("audit visitor is required")
 	}
-	_, err := scanAndVerify(l.file, visit)
+	_, err := scanAndVerify(l.file, l.cipher, visit)
 	return err
 }
 
@@ -588,7 +658,7 @@ func (l *Log) ReadReference(reference EntryReference) (Entry, error) {
 	if line[len(line)-1] != '\n' {
 		return Entry{}, errors.New("referenced audit entry is incomplete")
 	}
-	entry, err := decodeEntry(line[:len(line)-1])
+	entry, err := decodeEntry(line[:len(line)-1], l.cipher)
 	if err != nil {
 		return Entry{}, fmt.Errorf("decode referenced audit entry: %w", err)
 	}
@@ -608,7 +678,7 @@ func (l *Log) Verify() error {
 	if err := l.readyLocked(); err != nil {
 		return err
 	}
-	_, err := scanAndVerify(l.file, nil)
+	_, err := scanAndVerify(l.file, l.cipher, nil)
 	return err
 }
 
@@ -642,7 +712,11 @@ func ReadAll(dir string) ([]Entry, error) {
 		return nil, err
 	}
 	defer closeExistingAudit(directory, file)
-	return readAndVerify(file)
+	aead, err := loadAuditCipher(dir, false)
+	if err != nil {
+		return nil, fmt.Errorf("load audit encryption key: %w", err)
+	}
+	return readAndVerify(file, aead)
 }
 
 // Scan verifies the complete chain and calls visit once for each entry. Entries
@@ -656,7 +730,11 @@ func Scan(dir string, visit func(Entry) error) error {
 		return err
 	}
 	defer closeExistingAudit(directory, file)
-	_, err = scanAndVerify(file, func(entry Entry, _ EntryReference) error {
+	aead, err := loadAuditCipher(dir, false)
+	if err != nil {
+		return fmt.Errorf("load audit encryption key: %w", err)
+	}
+	_, err = scanAndVerify(file, aead, func(entry Entry, _ EntryReference) error {
 		return visit(entry)
 	})
 	return err
@@ -669,7 +747,11 @@ func Verify(dir string) error {
 		return err
 	}
 	defer closeExistingAudit(directory, file)
-	_, err = scanAndVerify(file, nil)
+	aead, err := loadAuditCipher(dir, false)
+	if err != nil {
+		return fmt.Errorf("load audit encryption key: %w", err)
+	}
+	_, err = scanAndVerify(file, aead, nil)
 	return err
 }
 
@@ -726,9 +808,9 @@ func cloneDetails(details map[string]string) map[string]string {
 	return cloned
 }
 
-func readAndVerify(file *os.File) ([]Entry, error) {
+func readAndVerify(file *os.File, aead cipher.AEAD) ([]Entry, error) {
 	entries := make([]Entry, 0)
-	_, err := scanAndVerify(file, func(entry Entry, _ EntryReference) error {
+	_, err := scanAndVerify(file, aead, func(entry Entry, _ EntryReference) error {
 		entries = append(entries, entry)
 		return nil
 	})
@@ -744,7 +826,7 @@ type scanSummary struct {
 	size int64
 }
 
-func scanAndVerify(file *os.File, visit func(Entry, EntryReference) error) (scanSummary, error) {
+func scanAndVerify(file *os.File, aead cipher.AEAD, visit func(Entry, EntryReference) error) (scanSummary, error) {
 	summary := scanSummary{head: genesisHash}
 	info, err := file.Stat()
 	if err != nil {
@@ -776,7 +858,7 @@ func scanAndVerify(file *os.File, visit func(Entry, EntryReference) error) (scan
 		if len(bytes.TrimSpace(line)) == 0 {
 			return summary, fmt.Errorf("entry %d is empty", expectedSeq)
 		}
-		entry, err := decodeEntry(line)
+		entry, err := decodeEntry(line, aead)
 		if err != nil {
 			return summary, fmt.Errorf("decode entry %d: %w", expectedSeq, err)
 		}
@@ -817,11 +899,37 @@ func splitAuditLines(data []byte, atEOF bool) (advance int, token []byte, err er
 	return 0, nil, nil
 }
 
-func decodeEntry(line []byte) (Entry, error) {
+func encryptEntry(aead cipher.AEAD, entry Entry) (storedEntry, error) {
+	if aead == nil {
+		return storedEntry{}, errors.New("audit cipher is required")
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return storedEntry{}, fmt.Errorf("generate audit nonce: %w", err)
+	}
+	payload, err := json.Marshal(storedPayload{
+		EventID: entry.EventID, ExchangeID: entry.ExchangeID, RequestID: entry.RequestID,
+		ConversationID: entry.ConversationID, Type: entry.Type, Status: entry.Status,
+		ErrorCode: entry.ErrorCode, Text: entry.Text, TextSHA256: entry.TextSHA256,
+		Details: entry.Details,
+	})
+	if err != nil {
+		return storedEntry{}, fmt.Errorf("encode audit payload: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, payload, []byte(entry.EntryHash))
+	return storedEntry{
+		Seq: entry.Seq, Timestamp: entry.Timestamp,
+		PayloadCiphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
+		PayloadNonce:      base64.RawStdEncoding.EncodeToString(nonce),
+		PreviousHash:      entry.PreviousHash, EntryHash: entry.EntryHash,
+	}, nil
+}
+
+func decodeEntry(line []byte, aead cipher.AEAD) (Entry, error) {
 	decoder := json.NewDecoder(bytes.NewReader(line))
 	decoder.DisallowUnknownFields()
-	var entry Entry
-	if err := decoder.Decode(&entry); err != nil {
+	var stored storedEntry
+	if err := decoder.Decode(&stored); err != nil {
 		return Entry{}, err
 	}
 	var extra any
@@ -831,12 +939,44 @@ func decodeEntry(line []byte) (Entry, error) {
 		}
 		return Entry{}, fmt.Errorf("trailing data: %w", err)
 	}
-	canonical, err := json.Marshal(entry)
+	canonical, err := json.Marshal(stored)
 	if err != nil {
 		return Entry{}, fmt.Errorf("encode canonical entry: %w", err)
 	}
 	if !bytes.Equal(line, canonical) {
 		return Entry{}, errors.New("entry is not canonical JSON")
+	}
+	if aead == nil {
+		return Entry{}, errors.New("audit cipher is required")
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(stored.PayloadNonce)
+	if err != nil || len(nonce) != aead.NonceSize() {
+		return Entry{}, errors.New("audit text nonce is invalid")
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(stored.PayloadCiphertext)
+	if err != nil || len(ciphertext) < aead.Overhead() {
+		return Entry{}, errors.New("audit text ciphertext is invalid")
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, []byte(stored.EntryHash))
+	if err != nil {
+		return Entry{}, errors.New("audit text authentication failed")
+	}
+	var payload storedPayload
+	payloadDecoder := json.NewDecoder(bytes.NewReader(plaintext))
+	payloadDecoder.DisallowUnknownFields()
+	if err := payloadDecoder.Decode(&payload); err != nil {
+		return Entry{}, errors.New("audit payload is invalid")
+	}
+	var payloadExtra any
+	if err := payloadDecoder.Decode(&payloadExtra); !errors.Is(err, io.EOF) {
+		return Entry{}, errors.New("audit payload has trailing data")
+	}
+	entry := Entry{
+		Seq: stored.Seq, EventID: payload.EventID, ExchangeID: payload.ExchangeID,
+		RequestID: payload.RequestID, ConversationID: payload.ConversationID,
+		Type: payload.Type, Status: payload.Status, ErrorCode: payload.ErrorCode,
+		Timestamp: stored.Timestamp, Text: payload.Text, TextSHA256: payload.TextSHA256,
+		Details: payload.Details, PreviousHash: stored.PreviousHash, EntryHash: stored.EntryHash,
 	}
 	return entry, nil
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,7 +25,9 @@ func TestAppendReadAllPreservesExactUnicodeAndPermissions(t *testing.T) {
 	t.Cleanup(func() { _ = log.Close() })
 
 	text := "precomposed caf\u00e9 / decomposed cafe\u0301\r\nemoji: \U0001f9d1\U0001f3fd\u200d\U0001f4bb\nquotes: \\\" <>& \u2028"
-	entry, err := log.Append(testEvent("event-1", text))
+	event := testEvent("event-1", text)
+	event.Details = map[string]string{"model_explanation": "sensitive-derived-detail"}
+	entry, err := log.Append(event)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,6 +75,20 @@ func TestAppendReadAllPreservesExactUnicodeAndPermissions(t *testing.T) {
 	}
 	if got := fileInfo.Mode().Perm(); got != 0o600 {
 		t.Fatalf("file mode = %o, want 600", got)
+	}
+	raw, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte(text)) || bytes.Contains(raw, []byte("sensitive-derived-detail")) || !bytes.Contains(raw, []byte(`"payload_ciphertext"`)) {
+		t.Fatalf("audit record exposed plaintext or omitted ciphertext: %q", raw)
+	}
+	keyInfo, err := os.Stat(filepath.Join(dir, keyFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := keyInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("key mode = %o, want 600", got)
 	}
 }
 
@@ -315,6 +332,31 @@ func TestReopenContinuesVerifiedChain(t *testing.T) {
 	}
 	if entry2.Seq != 2 || entry2.PreviousHash != entry1.EntryHash {
 		t.Fatalf("chain was not continued: %#v", entry2)
+	}
+}
+
+func TestMissingEncryptionKeyFailsClosedWithoutReplacement(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "audit")
+	log, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := log.Append(testEvent("event-1", "secret text")); err != nil {
+		t.Fatal(err)
+	}
+	if err := log.Close(); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, keyFileName)
+	if err := os.Remove(keyPath); err != nil {
+		t.Fatal(err)
+	}
+	if reopened, err := Open(dir); err == nil {
+		_ = reopened.Close()
+		t.Fatal("Open regenerated a missing key for a non-empty log")
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing key was replaced: %v", err)
 	}
 }
 
@@ -863,7 +905,7 @@ func TestWriteOrSyncUncertaintyPoisonsHandleUntilVerifiedReopen(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !strings.HasSuffix(string(raw), "\n") || !strings.Contains(string(raw), "fully written reply") {
+			if !strings.HasSuffix(string(raw), "\n") || strings.Contains(string(raw), "fully written reply") || !strings.Contains(string(raw), "payload_ciphertext") {
 				t.Fatalf("injected failure did not follow a complete write: %q", raw)
 			}
 

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -1,0 +1,111 @@
+// Package budget provides durable fail-closed fixed-window accounting.
+package budget
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/openclaw/turnwire/internal/securestore"
+)
+
+type state struct {
+	WindowStartedAt string `json:"window_started_at"`
+	Used            int    `json:"used"`
+}
+
+// Counter persists every admitted operation before returning success. A
+// corrupt or unwritable counter fails closed instead of granting a fresh
+// process-local allowance.
+type Counter struct {
+	mu     sync.Mutex
+	store  *securestore.Store
+	name   string
+	limit  int
+	window time.Duration
+	state  state
+}
+
+// Open loads a durable counter from an owner-only state directory.
+func Open(dir, name string, limit int, window time.Duration) (*Counter, error) {
+	if name == "" || limit <= 0 || window <= 0 {
+		return nil, errors.New("budget name, limit, and window are required")
+	}
+	store, err := securestore.Open(dir, true, "budget directory")
+	if err != nil {
+		return nil, err
+	}
+	counter := &Counter{store: store, name: "budget-" + name + ".json", limit: limit, window: window}
+	encoded, err := store.Read(counter.name)
+	if errors.Is(err, os.ErrNotExist) {
+		return counter, nil
+	}
+	if err != nil {
+		_ = store.Close()
+		return nil, fmt.Errorf("load %s budget: %w", name, err)
+	}
+	if err := json.Unmarshal(encoded, &counter.state); err != nil {
+		_ = store.Close()
+		return nil, fmt.Errorf("decode %s budget: %w", name, err)
+	}
+	if counter.state.Used < 0 || counter.state.WindowStartedAt == "" {
+		_ = store.Close()
+		return nil, fmt.Errorf("decode %s budget: invalid state", name)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, counter.state.WindowStartedAt); err != nil {
+		_ = store.Close()
+		return nil, fmt.Errorf("decode %s budget timestamp: %w", name, err)
+	}
+	return counter, nil
+}
+
+// Take durably charges one operation. Clock rollback preserves the existing
+// window until wall time catches up, preventing restart or time manipulation
+// from replenishing the allowance.
+func (c *Counter) Take(now time.Time) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.store == nil {
+		return false, errors.New("budget is closed")
+	}
+	now = now.UTC()
+	if c.state.WindowStartedAt == "" {
+		c.state.WindowStartedAt = now.Format(time.RFC3339Nano)
+	}
+	started, err := time.Parse(time.RFC3339Nano, c.state.WindowStartedAt)
+	if err != nil {
+		return false, err
+	}
+	if !now.Before(started) && now.Sub(started) >= c.window {
+		c.state = state{WindowStartedAt: now.Format(time.RFC3339Nano)}
+	}
+	if c.state.Used >= c.limit {
+		return false, nil
+	}
+	next := c.state
+	next.Used++
+	encoded, err := json.Marshal(next)
+	if err != nil {
+		return false, err
+	}
+	if err := c.store.Replace(c.name, encoded); err != nil {
+		return false, fmt.Errorf("persist budget: %w", err)
+	}
+	c.state = next
+	return true, nil
+}
+
+// Close releases the held state-directory descriptor.
+func (c *Counter) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.store == nil {
+		return nil
+	}
+	err := c.store.Close()
+	c.store = nil
+	return err
+}

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -1,0 +1,40 @@
+package budget
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCounterPersistsAcrossRestartAndClockRollback(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "state")
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	first, err := Open(dir, "guard", 2, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed, err := first.Take(now)
+	if err != nil || !allowed {
+		t.Fatalf("first take = %v, %v", allowed, err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Open(dir, "guard", 2, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	allowed, err = second.Take(now.Add(-time.Minute))
+	if err != nil || !allowed {
+		t.Fatalf("rollback take = %v, %v", allowed, err)
+	}
+	allowed, err = second.Take(now)
+	if err != nil || allowed {
+		t.Fatalf("exhausted take = %v, %v", allowed, err)
+	}
+	allowed, err = second.Take(now.Add(time.Hour))
+	if err != nil || !allowed {
+		t.Fatalf("new-window take = %v, %v", allowed, err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -245,6 +245,7 @@ const initHelp = `Usage:
 Flags:
   --force                       Replace an existing configuration
   --identity NAME               Endpoint identity (for example, work or personal)
+  --deployment-id ID            Tunnel or custom-app deployment identity
   --endpoint URL                OpenAI Responses endpoint
   --model NAME                  Guard model (default pinned GPT-5.4 snapshot)
   --api-key-env NAME            API key environment variable
@@ -272,6 +273,7 @@ const logHelp = `Usage:
   turnwire [global flags] log list [--conversation ID] [--limit N] [--json]
   turnwire [global flags] log show [--json] ID
   turnwire [global flags] log verify [--json]
+  turnwire [global flags] log export --output PATH
 `
 
 const versionHelp = `Usage:
@@ -279,11 +281,15 @@ const versionHelp = `Usage:
 `
 
 const identityHelp = `Usage:
-  turnwire [global flags] identity [--json]
+  turnwire [global flags] identity show [--json]
+  turnwire [global flags] identity rotate --force --output PATH
+  turnwire [global flags] identity revoke --force --output PATH
 `
 
 const peerHelp = `Usage:
   turnwire [global flags] peer add NAME PUBLIC_KEY
+  turnwire [global flags] peer rotate NAME ROTATION_FILE
+  turnwire [global flags] peer remove --force NAME
 `
 
 const approveHelp = `Usage:

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/openclaw/turnwire/internal/approval"
+	"github.com/openclaw/turnwire/internal/attestation"
 	"github.com/openclaw/turnwire/internal/audit"
 	"github.com/openclaw/turnwire/internal/buildinfo"
 	"github.com/openclaw/turnwire/internal/config"
@@ -22,6 +24,7 @@ import (
 	"github.com/openclaw/turnwire/internal/identity"
 	"github.com/openclaw/turnwire/internal/mailbox"
 	"github.com/openclaw/turnwire/internal/mcpserver"
+	"github.com/openclaw/turnwire/internal/owneronly"
 )
 
 const probeText = "Routine scheduling note: meeting moved to 10:30 tomorrow."
@@ -29,9 +32,10 @@ const probeText = "Routine scheduling note: meeting moved to 10:30 tomorrow."
 func runInit(args []string, opts options, stdout io.Writer) error {
 	flags := flag.NewFlagSet("init", flag.ContinueOnError)
 	var force, allowRemote bool
-	var identityName, endpoint, model, apiKeyEnv, policy, policyVersion, cacheRetention string
+	var identityName, deploymentID, endpoint, model, apiKeyEnv, policy, policyVersion, cacheRetention string
 	flags.BoolVar(&force, "force", false, "replace an existing configuration")
 	flags.StringVar(&identityName, "identity", "local", "endpoint identity name")
+	flags.StringVar(&deploymentID, "deployment-id", "", "tunnel or app deployment identity")
 	flags.StringVar(&endpoint, "endpoint", "", "OpenAI Responses endpoint")
 	flags.StringVar(&model, "model", "", "guard model")
 	flags.StringVar(&apiKeyEnv, "api-key-env", "", "API key environment variable")
@@ -49,6 +53,10 @@ func runInit(args []string, opts options, stdout io.Writer) error {
 
 	cfg := config.Default()
 	cfg.Identity.Name = identityName
+	cfg.Deployment.ID = identityName
+	if deploymentID != "" {
+		cfg.Deployment.ID = deploymentID
+	}
 	if endpoint != "" {
 		cfg.Guard.Endpoint = endpoint
 	}
@@ -193,6 +201,28 @@ func runServeWithGuard(ctx context.Context, args []string, opts options, stdin i
 	if err != nil {
 		return err
 	}
+	deployment, err := attestation.Measure(cfg, signer.PublicKey())
+	if err != nil {
+		return fmt.Errorf("measure deployment: %w", err)
+	}
+	modified := "unknown"
+	if deployment.Modified != nil {
+		modified = strconv.FormatBool(*deployment.Modified)
+	}
+	if _, err := log.Append(audit.Event{
+		EventID: "deployment:" + deployment.Digest, ExchangeID: "deployment:" + deployment.DeploymentID,
+		RequestID: "startup:" + deployment.Digest, ConversationID: "deployment:" + deployment.DeploymentID,
+		Type: "service_started", Status: "attested",
+		Details: map[string]string{
+			"deployment_id": deployment.DeploymentID, "deployment_sha256": deployment.Digest,
+			"executable_sha256": deployment.ExecutableSHA256, "config_sha256": deployment.ConfigSHA256,
+			"policy_sha256": deployment.PolicySHA256, "peer_set_sha256": deployment.PeerSetSHA256,
+			"identity_public_key": deployment.PublicKey, "version": deployment.Version,
+			"commit": deployment.Commit, "modified": modified,
+		},
+	}); err != nil {
+		return fmt.Errorf("record deployment attestation: %w", err)
+	}
 	timeout, _ := time.ParseDuration(cfg.Limits.Timeout)
 	maxAge, _ := time.ParseDuration(cfg.Limits.MaxMessageAge)
 	peers := make(map[string]string, len(cfg.Identity.Peers))
@@ -202,7 +232,8 @@ func runServeWithGuard(ctx context.Context, args []string, opts options, stdin i
 	service, err := mailbox.New(mailbox.Options{
 		Audit: log, Signer: signer, Peers: peers, Guard: modelGuard, Approvals: approvalStore,
 		Policy: cfg.Guard.Policy, PolicyVersion: cfg.Guard.PolicyVersion,
-		MaxMessageBytes: cfg.Limits.MaxMessageBytes, Timeout: timeout, MaxMessageAge: maxAge,
+		DeploymentSHA256: deployment.Digest,
+		MaxMessageBytes:  cfg.Limits.MaxMessageBytes, Timeout: timeout, MaxMessageAge: maxAge,
 		MaxConcurrent: cfg.Limits.MaxConcurrent, MaxRequestsPerMinute: cfg.Limits.MaxRequestsPerMinute,
 		MaxGuardCallsPerHour: cfg.Limits.MaxGuardCallsPerHour,
 	})
@@ -212,7 +243,7 @@ func runServeWithGuard(ctx context.Context, args []string, opts options, stdin i
 	if opts.verbose {
 		fmt.Fprintln(stderr, "turnwire: serving signed mailbox MCP over stdio")
 	}
-	serveErr := mcpserver.Run(ctx, service, buildinfo.Current().Version, stdin, stdout, cfg.Limits.MaxMessageBytes, cfg.Limits.MaxConcurrent, cfg.Limits.MaxRequestsPerMinute)
+	serveErr := mcpserver.Run(ctx, service, buildinfo.Current().Version, stdin, stdout, auditDir, cfg.Limits.MaxMessageBytes, cfg.Limits.MaxConcurrent, cfg.Limits.MaxRequestsPerMinute)
 	_ = service.Shutdown(context.Background())
 	if serveErr != nil {
 		if ctx.Err() != nil {
@@ -303,7 +334,23 @@ func runDoctor(ctx context.Context, args []string, opts options, stdout io.Write
 }
 
 func runIdentity(args []string, opts options, stdout io.Writer) error {
-	flags := flag.NewFlagSet("identity", flag.ContinueOnError)
+	if len(args) == 0 {
+		return usageError("usage: turnwire identity <show|rotate|revoke>")
+	}
+	switch args[0] {
+	case "show":
+		return runIdentityShow(args[1:], opts, stdout)
+	case "rotate":
+		return runIdentityRotate(args[1:], opts, stdout)
+	case "revoke":
+		return runIdentityRevoke(args[1:], opts, stdout)
+	default:
+		return usageError("unknown identity command %q", args[0])
+	}
+}
+
+func runIdentityShow(args []string, opts options, stdout io.Writer) error {
+	flags := flag.NewFlagSet("identity show", flag.ContinueOnError)
 	var asJSON bool
 	flags.BoolVar(&asJSON, "json", false, "emit JSON")
 	rest, help, err := parseFlags(flags, args, stdout, identityHelp)
@@ -333,8 +380,230 @@ func runIdentity(args []string, opts options, stdout io.Writer) error {
 	return err
 }
 
+func runIdentityRotate(args []string, opts options, stdout io.Writer) error {
+	flags := flag.NewFlagSet("identity rotate", flag.ContinueOnError)
+	var force bool
+	var output string
+	flags.BoolVar(&force, "force", false, "confirm private-key replacement")
+	flags.StringVar(&output, "output", "", "new owner-only transition certificate path")
+	rest, help, err := parseFlags(flags, args, stdout, identityHelp)
+	if err != nil || help {
+		return err
+	}
+	if err := requireNoArgs(rest); err != nil {
+		return err
+	}
+	if !force {
+		return usageError("identity rotate requires --force")
+	}
+	if output == "" {
+		return usageError("identity rotate requires --output")
+	}
+	cfg, auditDir, log, err := openIdentityOperation(opts)
+	if err != nil {
+		return err
+	}
+	defer log.Close()
+	plan, err := identity.PrepareRotation(auditDir, cfg.Identity.Name, time.Now())
+	if err != nil {
+		return err
+	}
+	rotation := plan.Certificate()
+	if err := writeLifecycleCertificate(output, rotation); err != nil {
+		return err
+	}
+	if _, err := log.Append(audit.Event{
+		EventID: "identity-rotation-prepared:" + rotation.NewPublicKey, ExchangeID: "identity:" + cfg.Identity.Name,
+		RequestID: "identity-rotation", ConversationID: "deployment:" + cfg.Deployment.ID,
+		Type: "identity_rotation_prepared", Status: "prepared",
+		Details: map[string]string{
+			"previous_public_key": rotation.PreviousPublicKey, "new_public_key": rotation.NewPublicKey,
+			"created_at": rotation.CreatedAt, "previous_signature": rotation.PreviousSignature,
+			"new_signature": rotation.NewSignature,
+		},
+	}); err != nil {
+		return fmt.Errorf("record prepared identity rotation: %w", err)
+	}
+	if err := plan.Commit(); err != nil {
+		return err
+	}
+	if _, err := log.Append(audit.Event{
+		EventID: "identity-rotation-completed:" + rotation.NewPublicKey, ExchangeID: "identity:" + cfg.Identity.Name,
+		RequestID: "identity-rotation", ConversationID: "deployment:" + cfg.Deployment.ID,
+		Type: "identity_rotated", Status: "completed",
+		Details: map[string]string{"previous_public_key": rotation.PreviousPublicKey, "new_public_key": rotation.NewPublicKey},
+	}); err != nil {
+		return fmt.Errorf("record completed identity rotation: %w", err)
+	}
+	if !opts.quiet {
+		_, err = fmt.Fprintf(stdout, "Rotated identity; certificate: %s\n", strconv.Quote(output))
+	}
+	return err
+}
+
+func runIdentityRevoke(args []string, opts options, stdout io.Writer) error {
+	flags := flag.NewFlagSet("identity revoke", flag.ContinueOnError)
+	var force bool
+	var output string
+	flags.BoolVar(&force, "force", false, "confirm private-key destruction")
+	flags.StringVar(&output, "output", "", "new owner-only revocation certificate path")
+	rest, help, err := parseFlags(flags, args, stdout, identityHelp)
+	if err != nil || help {
+		return err
+	}
+	if err := requireNoArgs(rest); err != nil {
+		return err
+	}
+	if !force {
+		return usageError("identity revoke requires --force")
+	}
+	if output == "" {
+		return usageError("identity revoke requires --output")
+	}
+	cfg, auditDir, log, err := openIdentityOperation(opts)
+	if err != nil {
+		return err
+	}
+	defer log.Close()
+	plan, err := identity.PrepareRevocation(auditDir, cfg.Identity.Name, time.Now())
+	if err != nil {
+		return err
+	}
+	revocation := plan.Certificate()
+	if _, err := log.Append(audit.Event{
+		EventID: "identity-revocation-prepared:" + revocation.PublicKey, ExchangeID: "identity:" + cfg.Identity.Name,
+		RequestID: "identity-revocation", ConversationID: "deployment:" + cfg.Deployment.ID,
+		Type: "identity_revocation_prepared", Status: "prepared",
+		Details: map[string]string{
+			"public_key": revocation.PublicKey, "created_at": revocation.CreatedAt,
+			"signature": revocation.Signature,
+		},
+	}); err != nil {
+		return fmt.Errorf("record prepared identity revocation: %w", err)
+	}
+	sequence, head, err := log.Head()
+	if err != nil {
+		return err
+	}
+	signer, err := identity.LoadOrCreate(auditDir, cfg.Identity.Name, false)
+	if err != nil {
+		return err
+	}
+	deployment, err := attestation.Measure(cfg, signer.PublicKey())
+	if err != nil {
+		return err
+	}
+	checkpoint, err := signer.Checkpoint(sequence, head, deployment.Digest, time.Now())
+	if err != nil {
+		return err
+	}
+	bundle := struct {
+		Revocation identity.Revocation `json:"revocation"`
+		Checkpoint identity.Checkpoint `json:"checkpoint"`
+	}{Revocation: revocation, Checkpoint: checkpoint}
+	if err := writeLifecycleCertificate(output, bundle); err != nil {
+		return err
+	}
+	if err := plan.Commit(); err != nil {
+		return err
+	}
+	if _, err := log.Append(audit.Event{
+		EventID: "identity-revocation-completed:" + revocation.PublicKey, ExchangeID: "identity:" + cfg.Identity.Name,
+		RequestID: "identity-revocation", ConversationID: "deployment:" + cfg.Deployment.ID,
+		Type: "identity_revoked", Status: "completed",
+		Details: map[string]string{"public_key": revocation.PublicKey},
+	}); err != nil {
+		return fmt.Errorf("record completed identity revocation: %w", err)
+	}
+	if !opts.quiet {
+		_, err = fmt.Fprintf(stdout, "Revoked identity; certificate: %s\n", strconv.Quote(output))
+	}
+	return err
+}
+
+func writeLifecycleCertificate(path string, value any) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode identity certificate: %w", err)
+	}
+	encoded = append(encoded, '\n')
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve identity certificate path: %w", err)
+	}
+	parent, _, err := owneronly.OpenDirectoryPathDurable(filepath.Dir(absolute), false, owneronly.DirectoryOwnerControlled, "certificate parent directory")
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	name := filepath.Base(absolute)
+	file, err := owneronly.OpenAtNoFollow(parent, name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create identity certificate: %w", err)
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = owneronly.UnlinkAt(parent, name)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := owneronly.Validate(file, owneronly.RegularFile, "identity certificate"); err != nil {
+		return err
+	}
+	if _, err := io.Copy(file, bytes.NewReader(encoded)); err != nil {
+		return fmt.Errorf("write identity certificate: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync identity certificate: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close identity certificate: %w", err)
+	}
+	if err := parent.Sync(); err != nil {
+		return fmt.Errorf("sync identity certificate directory: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+func openIdentityOperation(opts options) (config.Config, string, *audit.Log, error) {
+	cfg, err := config.Load(opts.configPath)
+	if err != nil {
+		return config.Config{}, "", nil, err
+	}
+	auditDir, err := resolveAuditDir(cfg, opts.dataDir)
+	if err != nil {
+		return config.Config{}, "", nil, err
+	}
+	log, err := openWritableAudit(auditDir, cfg.Limits.MaxAuditBytes)
+	if err != nil {
+		return config.Config{}, "", nil, fmt.Errorf("lock endpoint state: %w", err)
+	}
+	return cfg, auditDir, log, nil
+}
+
 func runPeer(args []string, opts options, stdout io.Writer) error {
-	if len(args) != 3 || args[0] != "add" {
+	if len(args) == 0 {
+		return usageError("usage: turnwire peer <add|rotate|remove>")
+	}
+	switch args[0] {
+	case "add":
+		return runPeerAdd(args[1:], opts, stdout)
+	case "rotate":
+		return runPeerRotate(args[1:], opts, stdout)
+	case "remove":
+		return runPeerRemove(args[1:], opts, stdout)
+	default:
+		return usageError("unknown peer command %q", args[0])
+	}
+}
+
+func runPeerAdd(args []string, opts options, stdout io.Writer) error {
+	if len(args) != 2 {
 		return usageError("usage: turnwire peer add NAME PUBLIC_KEY")
 	}
 	cfg, err := config.Load(opts.configPath)
@@ -342,11 +611,11 @@ func runPeer(args []string, opts options, stdout io.Writer) error {
 		return err
 	}
 	for _, peer := range cfg.Identity.Peers {
-		if peer.Name == args[1] {
-			return usageError("peer %q already exists", args[1])
+		if peer.Name == args[0] {
+			return usageError("peer %q already exists", args[0])
 		}
 	}
-	cfg.Identity.Peers = append(cfg.Identity.Peers, config.PeerConfig{Name: args[1], PublicKey: args[2]})
+	cfg.Identity.Peers = append(cfg.Identity.Peers, config.PeerConfig{Name: args[0], PublicKey: args[1]})
 	if err := cfg.Validate(); err != nil {
 		return usageError("%v", err)
 	}
@@ -358,7 +627,7 @@ func runPeer(args []string, opts options, stdout io.Writer) error {
 		return err
 	}
 	if !opts.quiet {
-		_, err = fmt.Fprintf(stdout, "Added peer %s\n", strconv.Quote(args[1]))
+		_, err = fmt.Fprintf(stdout, "Added peer %s\n", strconv.Quote(args[0]))
 	}
 	return err
 }
@@ -439,7 +708,11 @@ func runCheckpoint(args []string, opts options, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	checkpoint, err := signer.Checkpoint(seq, head, time.Now())
+	deployment, err := attestation.Measure(cfg, signer.PublicKey())
+	if err != nil {
+		return err
+	}
+	checkpoint, err := signer.Checkpoint(seq, head, deployment.Digest, time.Now())
 	if err != nil {
 		return err
 	}
@@ -455,6 +728,104 @@ func requireAuditCapacity(log *audit.Log) error {
 		return audit.ErrQuotaExceeded
 	}
 	return nil
+}
+
+func runPeerRotate(args []string, opts options, stdout io.Writer) error {
+	if len(args) != 2 {
+		return usageError("usage: turnwire peer rotate NAME ROTATION_FILE")
+	}
+	file, err := os.Open(args[1])
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(io.LimitReader(file, 64<<10))
+	decoder.DisallowUnknownFields()
+	var rotation identity.Rotation
+	if err := decoder.Decode(&rotation); err != nil {
+		return fmt.Errorf("decode identity rotation: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("decode identity rotation: multiple JSON values")
+		}
+		return fmt.Errorf("decode identity rotation: %w", err)
+	}
+	cfg, err := config.Load(opts.configPath)
+	if err != nil {
+		return err
+	}
+	found := false
+	for index := range cfg.Identity.Peers {
+		if cfg.Identity.Peers[index].Name != args[0] {
+			continue
+		}
+		if err := identity.VerifyRotation(rotation, args[0], cfg.Identity.Peers[index].PublicKey); err != nil {
+			return err
+		}
+		cfg.Identity.Peers[index].PublicKey = rotation.NewPublicKey
+		found = true
+		break
+	}
+	if !found {
+		return usageError("peer %q is not configured", args[0])
+	}
+	if err := writeUpdatedConfig(opts, cfg); err != nil {
+		return err
+	}
+	if !opts.quiet {
+		_, err = fmt.Fprintf(stdout, "Rotated peer %s to %s\n", args[0], rotation.NewPublicKey)
+	}
+	return err
+}
+
+func runPeerRemove(args []string, opts options, stdout io.Writer) error {
+	flags := flag.NewFlagSet("peer remove", flag.ContinueOnError)
+	var force bool
+	flags.BoolVar(&force, "force", false, "confirm peer removal")
+	rest, help, err := parseFlags(flags, args, stdout, peerHelp)
+	if err != nil || help {
+		return err
+	}
+	if len(rest) != 1 {
+		return usageError("usage: turnwire peer remove --force NAME")
+	}
+	if !force {
+		return usageError("peer remove requires --force")
+	}
+	cfg, err := config.Load(opts.configPath)
+	if err != nil {
+		return err
+	}
+	peers := cfg.Identity.Peers[:0]
+	found := false
+	for _, peer := range cfg.Identity.Peers {
+		if peer.Name == rest[0] {
+			found = true
+			continue
+		}
+		peers = append(peers, peer)
+	}
+	if !found {
+		return usageError("peer %q is not configured", rest[0])
+	}
+	cfg.Identity.Peers = peers
+	if err := writeUpdatedConfig(opts, cfg); err != nil {
+		return err
+	}
+	if !opts.quiet {
+		_, err = fmt.Fprintf(stdout, "Removed peer %s\n", rest[0])
+	}
+	return err
+}
+
+func writeUpdatedConfig(opts options, cfg config.Config) error {
+	path := opts.configPath
+	if path == "" {
+		path = config.DefaultConfigPath()
+	}
+	return config.Write(path, cfg, true)
 }
 func openWritableAudit(dir string, max int64) (*audit.Log, error) {
 	log, err := audit.OpenWithQuota(dir, max)

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -6,10 +6,16 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
+	"time"
 
+	"github.com/openclaw/turnwire/internal/attestation"
 	"github.com/openclaw/turnwire/internal/audit"
 	"github.com/openclaw/turnwire/internal/config"
+	"github.com/openclaw/turnwire/internal/identity"
+	"github.com/openclaw/turnwire/internal/owneronly"
 )
 
 const maxLogReadBytes = 16 << 20
@@ -25,9 +31,164 @@ func runLog(args []string, opts options, stdout io.Writer) error {
 		return runLogShow(args[1:], opts, stdout)
 	case "verify":
 		return runLogVerify(args[1:], opts, stdout)
+	case "export":
+		return runLogExport(args[1:], opts, stdout)
 	default:
 		return usageError("unknown log command %q", args[0])
 	}
+}
+
+type exportEntry struct {
+	Kind           string            `json:"kind"`
+	Sequence       uint64            `json:"sequence"`
+	EventID        string            `json:"event_id"`
+	ExchangeID     string            `json:"exchange_id"`
+	RequestID      string            `json:"request_id"`
+	ConversationID string            `json:"conversation_id"`
+	Type           string            `json:"type"`
+	Status         string            `json:"status"`
+	ErrorCode      string            `json:"error_code"`
+	Timestamp      string            `json:"timestamp"`
+	TextSHA256     string            `json:"text_sha256"`
+	Details        map[string]string `json:"details,omitempty"`
+	PreviousHash   string            `json:"previous_hash"`
+	EntryHash      string            `json:"entry_hash"`
+}
+
+type exportCheckpoint struct {
+	Kind       string              `json:"kind"`
+	Checkpoint identity.Checkpoint `json:"checkpoint"`
+}
+
+func runLogExport(args []string, opts options, stdout io.Writer) error {
+	flags := flag.NewFlagSet("log export", flag.ContinueOnError)
+	var output string
+	flags.StringVar(&output, "output", "", "new redacted JSONL export path")
+	rest, help, err := parseFlags(flags, args, stdout, logHelp)
+	if err != nil || help {
+		return err
+	}
+	if err := requireNoArgs(rest); err != nil {
+		return err
+	}
+	if output == "" {
+		return usageError("log export requires --output")
+	}
+	cfg, err := config.Load(opts.configPath)
+	if err != nil {
+		return err
+	}
+	dir, err := resolveAuditDir(cfg, opts.dataDir)
+	if err != nil {
+		return err
+	}
+	log, err := audit.OpenWithQuota(dir, cfg.Limits.MaxAuditBytes)
+	if err != nil {
+		return err
+	}
+	defer log.Close()
+	signer, err := identity.LoadOrCreate(dir, cfg.Identity.Name, false)
+	if err != nil {
+		return err
+	}
+	deployment, err := attestation.Measure(cfg, signer.PublicKey())
+	if err != nil {
+		return err
+	}
+	absolute, err := filepath.Abs(output)
+	if err != nil {
+		return fmt.Errorf("resolve audit export path: %w", err)
+	}
+	parent, _, err := owneronly.OpenDirectoryPathDurable(filepath.Dir(absolute), false, owneronly.DirectoryOwnerControlled, "audit export parent directory")
+	if err != nil {
+		return err
+	}
+	defer parent.Close()
+	name := filepath.Base(absolute)
+	aliases, err := log.AliasesEntry(parent, name)
+	if err != nil {
+		return err
+	}
+	if aliases {
+		return errors.New("export path must not name the audit log")
+	}
+	file, err := owneronly.OpenAtNoFollow(parent, name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create audit export: %w", err)
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = owneronly.UnlinkAt(parent, name)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := owneronly.Validate(file, owneronly.RegularFile, "audit export"); err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(file)
+	if err := log.Scan(func(entry audit.Entry) error {
+		return encoder.Encode(exportEntry{
+			Kind: "entry", Sequence: entry.Seq, EventID: entry.EventID, ExchangeID: entry.ExchangeID,
+			RequestID: entry.RequestID, ConversationID: entry.ConversationID, Type: entry.Type,
+			Status: entry.Status, ErrorCode: entry.ErrorCode, Timestamp: entry.Timestamp,
+			TextSHA256: entry.TextSHA256, Details: exportDetails(entry.Details),
+			PreviousHash: entry.PreviousHash, EntryHash: entry.EntryHash,
+		})
+	}); err != nil {
+		return err
+	}
+	sequence, head, err := log.Head()
+	if err != nil {
+		return err
+	}
+	checkpoint, err := signer.Checkpoint(sequence, head, deployment.Digest, time.Now())
+	if err != nil {
+		return err
+	}
+	if err := encoder.Encode(exportCheckpoint{Kind: "checkpoint", Checkpoint: checkpoint}); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := parent.Sync(); err != nil {
+		return err
+	}
+	complete = true
+	if !opts.quiet {
+		_, err = fmt.Fprintf(stdout, "Exported redacted audit metadata to %s\n", strconv.Quote(output))
+	}
+	return err
+}
+
+func exportDetails(details map[string]string) map[string]string {
+	allowed := map[string]bool{
+		"direction": true, "source": true, "destination": true, "message_id": true,
+		"body_sha256": true, "envelope_sha256": true, "acknowledgement": true,
+		"model": true, "provider_request_id": true, "provider_response_id": true,
+		"decision": true, "reason_code": true, "policy_version": true,
+		"identity": true, "message_count": true,
+		"deployment_id": true, "deployment_sha256": true, "executable_sha256": true,
+		"config_sha256": true, "policy_sha256": true, "peer_set_sha256": true,
+		"identity_public_key": true, "version": true, "commit": true, "modified": true,
+	}
+	filtered := make(map[string]string)
+	for key, value := range details {
+		if allowed[key] {
+			filtered[key] = value
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 func runLogList(args []string, opts options, stdout io.Writer) error {

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+func TestExportDetailsKeepsReconciliationEvidenceAndDropsExplanations(t *testing.T) {
+	details := map[string]string{
+		"provider_request_id":  "request-id",
+		"provider_response_id": "response-id",
+		"envelope_sha256":      "envelope-hash",
+		"acknowledgement":      `{"signature":"signed"}`,
+		"explanation":          "derived sensitive explanation",
+		"unexpected":           "private metadata",
+	}
+	exported := exportDetails(details)
+	for _, key := range []string{"provider_request_id", "provider_response_id", "envelope_sha256", "acknowledgement"} {
+		if exported[key] != details[key] {
+			t.Fatalf("export omitted %s", key)
+		}
+	}
+	for _, key := range []string{"explanation", "unexpected"} {
+		if _, exists := exported[key]; exists {
+			t.Fatalf("export leaked %s", key)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,10 +41,17 @@ const (
 
 // Config is the complete Turnwire configuration.
 type Config struct {
-	Identity IdentityConfig `json:"identity"`
-	Guard    GuardConfig    `json:"guard"`
-	Limits   LimitsConfig   `json:"limits"`
-	AuditDir string         `json:"audit_dir,omitempty"`
+	Identity   IdentityConfig   `json:"identity"`
+	Deployment DeploymentConfig `json:"deployment"`
+	Guard      GuardConfig      `json:"guard"`
+	Limits     LimitsConfig     `json:"limits"`
+	AuditDir   string           `json:"audit_dir,omitempty"`
+}
+
+// DeploymentConfig identifies the tunnel/app association represented in
+// startup attestations and signed checkpoints.
+type DeploymentConfig struct {
+	ID string `json:"id"`
 }
 
 // IdentityConfig names this endpoint and lists the public keys it trusts.
@@ -222,6 +229,9 @@ func (c Config) Validate() error {
 	if !validName(c.Identity.Name) {
 		return errors.New("config.identity.name must use 1-64 ASCII letters, digits, dot, underscore, colon, or hyphen")
 	}
+	if !validName(c.Deployment.ID) {
+		return errors.New("config.deployment.id must use 1-64 ASCII letters, digits, dot, underscore, colon, or hyphen")
+	}
 	seenPeers := make(map[string]struct{}, len(c.Identity.Peers))
 	for _, peer := range c.Identity.Peers {
 		if !validName(peer.Name) || peer.Name == c.Identity.Name {
@@ -381,7 +391,8 @@ func validName(value string) bool {
 
 func defaultConfig() Config {
 	return Config{
-		Identity: IdentityConfig{Name: "local", Peers: []PeerConfig{}},
+		Identity:   IdentityConfig{Name: "local", Peers: []PeerConfig{}},
+		Deployment: DeploymentConfig{ID: "local"},
 		Guard: GuardConfig{
 			API:                  "responses",
 			Endpoint:             defaultEndpoint,

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -4,11 +4,14 @@ package identity
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/openclaw/turnwire/internal/securestore"
@@ -98,33 +101,237 @@ func Verify(publicKeyText string, value any, signatureText string) error {
 
 // Checkpoint is an independently storable signed audit head.
 type Checkpoint struct {
-	Version   int    `json:"version"`
+	Version          int    `json:"version"`
+	Identity         string `json:"identity"`
+	PublicKey        string `json:"public_key"`
+	Sequence         uint64 `json:"sequence"`
+	AuditHead        string `json:"audit_head"`
+	DeploymentSHA256 string `json:"deployment_sha256"`
+	CreatedAt        string `json:"created_at"`
+	Signature        string `json:"signature"`
+}
+
+type unsignedCheckpoint struct {
+	Version          int    `json:"version"`
+	Identity         string `json:"identity"`
+	PublicKey        string `json:"public_key"`
+	Sequence         uint64 `json:"sequence"`
+	AuditHead        string `json:"audit_head"`
+	DeploymentSHA256 string `json:"deployment_sha256"`
+	CreatedAt        string `json:"created_at"`
+}
+
+// Rotation proves continuity from the currently pinned key to a new key. Both
+// keys sign the transition before the old private key is atomically replaced.
+type Rotation struct {
+	Identity          string `json:"identity"`
+	PreviousPublicKey string `json:"previous_public_key"`
+	NewPublicKey      string `json:"new_public_key"`
+	CreatedAt         string `json:"created_at"`
+	PreviousSignature string `json:"previous_signature"`
+	NewSignature      string `json:"new_signature"`
+}
+
+type unsignedRotation struct {
+	Identity          string `json:"identity"`
+	PreviousPublicKey string `json:"previous_public_key"`
+	NewPublicKey      string `json:"new_public_key"`
+	CreatedAt         string `json:"created_at"`
+}
+
+type countersignedRotation struct {
+	unsignedRotation
+	PreviousSignature string `json:"previous_signature"`
+}
+
+// Revocation proves that the local identity intentionally destroyed its
+// private key. Peers must remove the pinned key separately.
+type Revocation struct {
 	Identity  string `json:"identity"`
 	PublicKey string `json:"public_key"`
-	Sequence  uint64 `json:"sequence"`
-	AuditHead string `json:"audit_head"`
 	CreatedAt string `json:"created_at"`
 	Signature string `json:"signature"`
 }
 
-type unsignedCheckpoint struct {
-	Version   int    `json:"version"`
+type unsignedRevocation struct {
 	Identity  string `json:"identity"`
 	PublicKey string `json:"public_key"`
-	Sequence  uint64 `json:"sequence"`
-	AuditHead string `json:"audit_head"`
 	CreatedAt string `json:"created_at"`
 }
 
-// Checkpoint signs a current audit head for independent anchoring.
-func (s *Signer) Checkpoint(sequence uint64, head string, now time.Time) (Checkpoint, error) {
-	unsigned := unsignedCheckpoint{
-		Version:   1,
-		Identity:  s.name,
-		PublicKey: s.PublicKey(),
-		Sequence:  sequence,
-		AuditHead: head,
+// RotationPlan holds a signed transition until its caller has durably recorded
+// the certificate. Commit then atomically replaces the old private key.
+type RotationPlan struct {
+	auditDir      string
+	newPrivateKey ed25519.PrivateKey
+	rotation      Rotation
+}
+
+// Certificate returns the dual-signed public transition.
+func (p *RotationPlan) Certificate() Rotation { return p.rotation }
+
+// PrepareRotation creates a transition without mutating the current identity.
+func PrepareRotation(auditDir, name string, now time.Time) (*RotationPlan, error) {
+	store, err := securestore.Open(auditDir, false, "identity directory")
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	oldBytes, err := store.Read(keyFileName)
+	if err != nil {
+		return nil, fmt.Errorf("load identity key: %w", err)
+	}
+	oldSigner, err := newSigner(name, oldBytes)
+	if err != nil {
+		return nil, err
+	}
+	_, newBytes, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate identity key: %w", err)
+	}
+	newSigner, err := newSigner(name, newBytes)
+	if err != nil {
+		return nil, err
+	}
+	unsigned := unsignedRotation{
+		Identity: name, PreviousPublicKey: oldSigner.PublicKey(), NewPublicKey: newSigner.PublicKey(),
 		CreatedAt: now.UTC().Format(time.RFC3339Nano),
+	}
+	previousSignature, err := oldSigner.Sign(unsigned)
+	if err != nil {
+		return nil, err
+	}
+	newSignature, err := newSigner.Sign(countersignedRotation{unsignedRotation: unsigned, PreviousSignature: previousSignature})
+	if err != nil {
+		return nil, err
+	}
+	rotation := Rotation{
+		Identity: unsigned.Identity, PreviousPublicKey: unsigned.PreviousPublicKey, NewPublicKey: unsigned.NewPublicKey,
+		CreatedAt: unsigned.CreatedAt, PreviousSignature: previousSignature, NewSignature: newSignature,
+	}
+	return &RotationPlan{auditDir: auditDir, newPrivateKey: newBytes, rotation: rotation}, nil
+}
+
+// Commit replaces the key only if the current identity still matches the
+// certificate's previous key.
+func (p *RotationPlan) Commit() error {
+	if p == nil || len(p.newPrivateKey) != ed25519.PrivateKeySize {
+		return errors.New("identity rotation plan is unavailable")
+	}
+	store, err := securestore.Open(p.auditDir, false, "identity directory")
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	current, err := store.Read(keyFileName)
+	if err != nil {
+		return fmt.Errorf("load identity key: %w", err)
+	}
+	currentSigner, err := newSigner(p.rotation.Identity, current)
+	if err != nil {
+		return err
+	}
+	if currentSigner.PublicKey() != p.rotation.PreviousPublicKey {
+		return errors.New("identity changed after rotation was prepared")
+	}
+	if err := store.Replace(keyFileName, p.newPrivateKey); err != nil {
+		return fmt.Errorf("replace identity key: %w", err)
+	}
+	clear(p.newPrivateKey)
+	p.newPrivateKey = nil
+	return nil
+}
+
+// VerifyRotation verifies both signatures and the expected currently pinned
+// identity. A transition for any other key or peer fails closed.
+func VerifyRotation(rotation Rotation, identityName, pinnedPublicKey string) error {
+	if rotation.Identity != identityName || rotation.PreviousPublicKey != pinnedPublicKey || rotation.NewPublicKey == rotation.PreviousPublicKey {
+		return errors.New("identity rotation does not match the pinned peer")
+	}
+	unsigned := unsignedRotation{
+		Identity: rotation.Identity, PreviousPublicKey: rotation.PreviousPublicKey,
+		NewPublicKey: rotation.NewPublicKey, CreatedAt: rotation.CreatedAt,
+	}
+	if _, err := time.Parse(time.RFC3339Nano, rotation.CreatedAt); err != nil {
+		return errors.New("identity rotation timestamp is invalid")
+	}
+	if err := Verify(rotation.PreviousPublicKey, unsigned, rotation.PreviousSignature); err != nil {
+		return fmt.Errorf("verify previous identity signature: %w", err)
+	}
+	if err := Verify(rotation.NewPublicKey, countersignedRotation{unsignedRotation: unsigned, PreviousSignature: rotation.PreviousSignature}, rotation.NewSignature); err != nil {
+		return fmt.Errorf("verify new identity signature: %w", err)
+	}
+	return nil
+}
+
+// RevocationPlan holds a signed final certificate until the caller has
+// durably recorded it.
+type RevocationPlan struct {
+	auditDir   string
+	revocation Revocation
+}
+
+// Certificate returns the signed public revocation evidence.
+func (p *RevocationPlan) Certificate() Revocation { return p.revocation }
+
+// PrepareRevocation signs a certificate without deleting the private key.
+func PrepareRevocation(auditDir, name string, now time.Time) (*RevocationPlan, error) {
+	signer, err := LoadOrCreate(auditDir, name, false)
+	if err != nil {
+		return nil, err
+	}
+	unsigned := unsignedRevocation{Identity: name, PublicKey: signer.PublicKey(), CreatedAt: now.UTC().Format(time.RFC3339Nano)}
+	signature, err := signer.Sign(unsigned)
+	if err != nil {
+		return nil, err
+	}
+	return &RevocationPlan{auditDir: auditDir, revocation: Revocation{
+		Identity: unsigned.Identity, PublicKey: unsigned.PublicKey, CreatedAt: unsigned.CreatedAt, Signature: signature,
+	}}, nil
+}
+
+// Commit deletes the key only if it still matches the prepared certificate.
+func (p *RevocationPlan) Commit() error {
+	if p == nil || p.revocation.PublicKey == "" {
+		return errors.New("identity revocation plan is unavailable")
+	}
+	store, err := securestore.Open(p.auditDir, false, "identity directory")
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	current, err := store.Read(keyFileName)
+	if err != nil {
+		return fmt.Errorf("load identity key: %w", err)
+	}
+	currentSigner, err := newSigner(p.revocation.Identity, current)
+	if err != nil {
+		return err
+	}
+	if currentSigner.PublicKey() != p.revocation.PublicKey {
+		return errors.New("identity changed after revocation was prepared")
+	}
+	if err := store.Delete(keyFileName); err != nil {
+		return fmt.Errorf("delete identity key: %w", err)
+	}
+	p.revocation.PublicKey = ""
+	return nil
+}
+
+// Checkpoint signs a current audit head for independent anchoring.
+func (s *Signer) Checkpoint(sequence uint64, head, deploymentSHA256 string, now time.Time) (Checkpoint, error) {
+	decodedDeployment, decodeErr := hex.DecodeString(deploymentSHA256)
+	if decodeErr != nil || len(decodedDeployment) != sha256.Size || deploymentSHA256 != strings.ToLower(deploymentSHA256) {
+		return Checkpoint{}, errors.New("deployment SHA-256 is required")
+	}
+	unsigned := unsignedCheckpoint{
+		Version:          1,
+		Identity:         s.name,
+		PublicKey:        s.PublicKey(),
+		Sequence:         sequence,
+		AuditHead:        head,
+		DeploymentSHA256: deploymentSHA256,
+		CreatedAt:        now.UTC().Format(time.RFC3339Nano),
 	}
 	signature, err := s.Sign(unsigned)
 	if err != nil {
@@ -132,7 +339,8 @@ func (s *Signer) Checkpoint(sequence uint64, head string, now time.Time) (Checkp
 	}
 	return Checkpoint{
 		Version: unsigned.Version, Identity: unsigned.Identity, PublicKey: unsigned.PublicKey, Sequence: unsigned.Sequence,
-		AuditHead: unsigned.AuditHead, CreatedAt: unsigned.CreatedAt, Signature: signature,
+		AuditHead: unsigned.AuditHead, DeploymentSHA256: unsigned.DeploymentSHA256,
+		CreatedAt: unsigned.CreatedAt, Signature: signature,
 	}, nil
 }
 
@@ -141,7 +349,8 @@ func (s *Signer) Checkpoint(sequence uint64, head string, now time.Time) (Checkp
 func VerifyCheckpoint(checkpoint Checkpoint) error {
 	unsigned := unsignedCheckpoint{
 		Version: checkpoint.Version, Identity: checkpoint.Identity, PublicKey: checkpoint.PublicKey,
-		Sequence: checkpoint.Sequence, AuditHead: checkpoint.AuditHead, CreatedAt: checkpoint.CreatedAt,
+		Sequence: checkpoint.Sequence, AuditHead: checkpoint.AuditHead,
+		DeploymentSHA256: checkpoint.DeploymentSHA256, CreatedAt: checkpoint.CreatedAt,
 	}
 	return Verify(checkpoint.PublicKey, unsigned, checkpoint.Signature)
 }

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,7 +1,10 @@
 package identity
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -33,7 +36,7 @@ func TestIdentityPersistsSignsAndCheckpoints(t *testing.T) {
 	if err := Verify(first.PublicKey(), value, signature); err == nil {
 		t.Fatal("tampered value verified")
 	}
-	checkpoint, err := first.Checkpoint(7, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", time.Unix(1, 0))
+	checkpoint, err := first.Checkpoint(7, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789", time.Unix(1, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,5 +49,57 @@ func TestIdentityPersistsSignsAndCheckpoints(t *testing.T) {
 	checkpoint.AuditHead = "tampered"
 	if err := VerifyCheckpoint(checkpoint); err == nil {
 		t.Fatal("tampered checkpoint verified")
+	}
+}
+
+func TestRotationProvesContinuityAndRevocationDeletesKey(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "identity")
+	original, err := LoadOrCreate(dir, "work", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotationPlan, err := PrepareRotation(dir, "work", time.Unix(2, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotation := rotationPlan.Certificate()
+	if err := VerifyRotation(rotation, "work", original.PublicKey()); err != nil {
+		t.Fatal(err)
+	}
+	beforeCommit, err := LoadOrCreate(dir, "work", false)
+	if err != nil || beforeCommit.PublicKey() != original.PublicKey() {
+		t.Fatal("preparing rotation changed the identity")
+	}
+	if err := rotationPlan.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	rotated, err := LoadOrCreate(dir, "work", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotated.PublicKey() != rotation.NewPublicKey || rotated.PublicKey() == original.PublicKey() {
+		t.Fatal("rotation did not replace the local identity key")
+	}
+	tampered := rotation
+	tampered.NewPublicKey = original.PublicKey()
+	if err := VerifyRotation(tampered, "work", original.PublicKey()); err == nil {
+		t.Fatal("tampered rotation verified")
+	}
+	revocationPlan, err := PrepareRevocation(dir, "work", time.Unix(3, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	revocation := revocationPlan.Certificate()
+	if stillPresent, err := LoadOrCreate(dir, "work", false); err != nil || stillPresent.PublicKey() != rotated.PublicKey() {
+		t.Fatal("preparing revocation deleted the identity")
+	}
+	if err := revocationPlan.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if revocation.PublicKey != rotated.PublicKey() || revocation.Signature == "" {
+		t.Fatalf("revocation = %#v", revocation)
+	}
+	if _, err := LoadOrCreate(dir, "work", false); !errors.Is(err, os.ErrNotExist) && (err == nil || !strings.Contains(err.Error(), "no such file")) {
+		t.Fatalf("load revoked identity error = %v", err)
 	}
 }

--- a/internal/mailbox/budget.go
+++ b/internal/mailbox/budget.go
@@ -16,7 +16,7 @@ func newWindowBudget(limit int, window time.Duration) *windowBudget {
 	return &windowBudget{limit: limit, window: window, used: make([]time.Time, 0, limit)}
 }
 
-func (b *windowBudget) take(now time.Time) bool {
+func (b *windowBudget) Take(now time.Time) (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -33,8 +33,8 @@ func (b *windowBudget) take(now time.Time) bool {
 		b.used = b.used[:0]
 	}
 	if len(b.used) >= b.limit {
-		return false
+		return false, nil
 	}
 	b.used = append(b.used, now)
-	return true
+	return true, nil
 }

--- a/internal/mailbox/budget_test.go
+++ b/internal/mailbox/budget_test.go
@@ -8,13 +8,23 @@ import (
 func TestWindowBudgetExpiresAndHandlesClockRollback(t *testing.T) {
 	budget := newWindowBudget(1, time.Minute)
 	now := time.Unix(1000, 0)
-	if !budget.take(now) || budget.take(now) {
+	first, err := budget.Take(now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := budget.Take(now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first || second {
 		t.Fatal("budget did not enforce its limit")
 	}
-	if !budget.take(now.Add(time.Minute)) {
+	allowed, err := budget.Take(now.Add(time.Minute))
+	if err != nil || !allowed {
 		t.Fatal("budget did not expire its window")
 	}
-	if !budget.take(now.Add(-time.Minute)) {
+	allowed, err = budget.Take(now.Add(-time.Minute))
+	if err != nil || !allowed {
 		t.Fatal("budget did not reset after clock rollback")
 	}
 }

--- a/internal/mailbox/service.go
+++ b/internal/mailbox/service.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/openclaw/turnwire/internal/approval"
 	"github.com/openclaw/turnwire/internal/audit"
+	"github.com/openclaw/turnwire/internal/budget"
 	"github.com/openclaw/turnwire/internal/guard"
 	"github.com/openclaw/turnwire/internal/identity"
 )
@@ -41,6 +43,7 @@ type Options struct {
 	Approvals            *approval.Store
 	Policy               string
 	PolicyVersion        string
+	DeploymentSHA256     string
 	MaxMessageBytes      int
 	Timeout              time.Duration
 	MaxMessageAge        time.Duration
@@ -66,22 +69,24 @@ type receivedRecord struct {
 }
 
 type Service struct {
-	audit           *audit.Log
-	signer          *identity.Signer
-	peers           map[string]string
-	guard           guard.Evaluator
-	approvals       *approval.Store
-	policy          string
-	policyVersion   string
-	maxMessageBytes int
-	timeout         time.Duration
-	maxMessageAge   time.Duration
-	semaphore       chan struct{}
-	requestBudget   *windowBudget
-	guardBudget     *windowBudget
-	now             func() time.Time
-	lifecycleCtx    context.Context
-	lifecycleCancel context.CancelFunc
+	audit            *audit.Log
+	signer           *identity.Signer
+	peers            map[string]string
+	guard            guard.Evaluator
+	approvals        *approval.Store
+	policy           string
+	policyVersion    string
+	deploymentSHA256 string
+	maxMessageBytes  int
+	timeout          time.Duration
+	maxMessageAge    time.Duration
+	semaphore        chan struct{}
+	requestBudget    limiter
+	guardBudget      limiter
+	budgetClosers    []*budget.Counter
+	now              func() time.Time
+	lifecycleCtx     context.Context
+	lifecycleCancel  context.CancelFunc
 
 	mu           sync.Mutex
 	closing      bool
@@ -97,6 +102,21 @@ type Service struct {
 	drained      chan struct{}
 }
 
+type limiter interface {
+	Take(time.Time) (bool, error)
+}
+
+func takeBudget(counter limiter, now time.Time) error {
+	allowed, err := counter.Take(now)
+	if err != nil {
+		return fmt.Errorf("%w: durable budget unavailable", ErrRateLimited)
+	}
+	if !allowed {
+		return ErrRateLimited
+	}
+	return nil
+}
+
 func New(opts Options) (*Service, error) {
 	if opts.Audit == nil || opts.Signer == nil || opts.Guard == nil || opts.Approvals == nil {
 		return nil, errors.New("audit, identity, guard, and approval store are required")
@@ -109,18 +129,35 @@ func New(opts Options) (*Service, error) {
 	if strings.TrimSpace(opts.Policy) == "" || strings.TrimSpace(opts.PolicyVersion) == "" {
 		return nil, errors.New("guard policy and version are required")
 	}
+	if len(opts.DeploymentSHA256) != 64 {
+		return nil, errors.New("deployment SHA-256 is required")
+	}
 	now := opts.Now
 	if now == nil {
 		now = time.Now
 	}
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
+	budgetDir := filepath.Dir(opts.Audit.Path())
+	requestBudget, err := budget.Open(budgetDir, "service-requests", opts.MaxRequestsPerMinute, time.Minute)
+	if err != nil {
+		lifecycleCancel()
+		return nil, fmt.Errorf("open request budget: %w", err)
+	}
+	guardBudget, err := budget.Open(budgetDir, "guard-calls", opts.MaxGuardCallsPerHour, time.Hour)
+	if err != nil {
+		_ = requestBudget.Close()
+		lifecycleCancel()
+		return nil, fmt.Errorf("open guard budget: %w", err)
+	}
 	service := &Service{
 		audit: opts.Audit, signer: opts.Signer, peers: clonePeers(opts.Peers), guard: opts.Guard,
 		approvals: opts.Approvals, policy: opts.Policy, policyVersion: opts.PolicyVersion,
-		maxMessageBytes: opts.MaxMessageBytes, timeout: opts.Timeout, maxMessageAge: opts.MaxMessageAge,
+		deploymentSHA256: opts.DeploymentSHA256,
+		maxMessageBytes:  opts.MaxMessageBytes, timeout: opts.Timeout, maxMessageAge: opts.MaxMessageAge,
 		semaphore:     make(chan struct{}, opts.MaxConcurrent),
-		requestBudget: newWindowBudget(opts.MaxRequestsPerMinute, time.Minute),
-		guardBudget:   newWindowBudget(opts.MaxGuardCallsPerHour, time.Hour),
+		requestBudget: requestBudget,
+		guardBudget:   guardBudget,
+		budgetClosers: []*budget.Counter{requestBudget, guardBudget},
 		now:           now,
 		active:        make(map[string]string), requests: make(map[string]requestRecord),
 		sent: make(map[string]Envelope), received: make(map[string]receivedRecord), seenInbound: make(map[string]string),
@@ -128,6 +165,8 @@ func New(opts Options) (*Service, error) {
 		drained:   make(chan struct{}), lifecycleCtx: lifecycleCtx, lifecycleCancel: lifecycleCancel,
 	}
 	if err := service.rebuildIndex(); err != nil {
+		_ = requestBudget.Close()
+		_ = guardBudget.Close()
 		lifecycleCancel()
 		return nil, err
 	}
@@ -138,8 +177,11 @@ func (s *Service) Send(ctx context.Context, input SendInput) (SendOutput, error)
 	if err := ctx.Err(); err != nil {
 		return SendOutput{}, err
 	}
-	if !s.requestBudget.take(s.now()) {
-		return SendOutput{}, ErrRateLimited
+	if s.isClosing() {
+		return SendOutput{}, ErrClosed
+	}
+	if err := takeBudget(s.requestBudget, s.now()); err != nil {
+		return SendOutput{}, err
 	}
 	input, err := normalizeSend(input, s.maxMessageBytes)
 	if err != nil {
@@ -249,8 +291,11 @@ func (s *Service) Receive(ctx context.Context, input ReceiveInput) (ReceiveOutpu
 	if err := ctx.Err(); err != nil {
 		return ReceiveOutput{}, err
 	}
-	if !s.requestBudget.take(s.now()) {
-		return ReceiveOutput{}, ErrRateLimited
+	if s.isClosing() {
+		return ReceiveOutput{}, ErrClosed
+	}
+	if err := takeBudget(s.requestBudget, s.now()); err != nil {
+		return ReceiveOutput{}, err
 	}
 	envelope := input.Envelope
 	envelopeHash, err := s.validateEnvelope(envelope)
@@ -379,8 +424,11 @@ func (s *Service) Confirm(ctx context.Context, input ConfirmInput) (ConfirmOutpu
 	if err := ctx.Err(); err != nil {
 		return ConfirmOutput{}, err
 	}
-	if !s.requestBudget.take(s.now()) {
-		return ConfirmOutput{}, ErrRateLimited
+	if s.isClosing() {
+		return ConfirmOutput{}, ErrClosed
+	}
+	if err := takeBudget(s.requestBudget, s.now()); err != nil {
+		return ConfirmOutput{}, err
 	}
 	ack := input.Acknowledgement
 	if ack.Version != 1 || !validID(ack.MessageID) || !validID(ack.Source) || ack.Destination != s.signer.Name() ||
@@ -431,8 +479,11 @@ func (s *Service) Confirm(ctx context.Context, input ConfirmInput) (ConfirmOutpu
 }
 
 func (s *Service) Inbox(_ context.Context, input InboxInput) (InboxOutput, error) {
-	if !s.requestBudget.take(s.now()) {
-		return InboxOutput{}, ErrRateLimited
+	if s.isClosing() {
+		return InboxOutput{}, ErrClosed
+	}
+	if err := takeBudget(s.requestBudget, s.now()); err != nil {
+		return InboxOutput{}, err
 	}
 	release, err := s.beginOperation()
 	if err != nil {
@@ -490,8 +541,11 @@ func (s *Service) Inbox(_ context.Context, input InboxInput) (InboxOutput, error
 }
 
 func (s *Service) Checkpoint() (identity.Checkpoint, error) {
-	if !s.requestBudget.take(s.now()) {
-		return identity.Checkpoint{}, ErrRateLimited
+	if s.isClosing() {
+		return identity.Checkpoint{}, ErrClosed
+	}
+	if err := takeBudget(s.requestBudget, s.now()); err != nil {
+		return identity.Checkpoint{}, err
 	}
 	release, err := s.beginOperation()
 	if err != nil {
@@ -502,7 +556,13 @@ func (s *Service) Checkpoint() (identity.Checkpoint, error) {
 	if err != nil {
 		return identity.Checkpoint{}, err
 	}
-	return s.signer.Checkpoint(sequence, head, s.now())
+	return s.signer.Checkpoint(sequence, head, s.deploymentSHA256, s.now())
+}
+
+func (s *Service) isClosing() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closing
 }
 
 func (s *Service) Shutdown(ctx context.Context) error {
@@ -517,7 +577,11 @@ func (s *Service) Shutdown(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-s.drained:
-		return nil
+		var closeErr error
+		for _, counter := range s.budgetClosers {
+			closeErr = errors.Join(closeErr, counter.Close())
+		}
+		return closeErr
 	}
 }
 
@@ -539,12 +603,12 @@ func (s *Service) evaluate(ctx context.Context, messageID, requestID, conversati
 	if deterministicDecision == guard.DecisionDeny {
 		return deterministicDecision, deterministicReason, guard.Evaluation{Model: "not_called"}, entry, nil
 	}
-	if !s.guardBudget.take(s.now()) {
+	if err := takeBudget(s.guardBudget, s.now()); err != nil {
 		failed, appendErr := s.appendEvent(messageID, requestID, conversationID, eventGuardFailed, "failed", "guard_budget_exhausted", "", messageDetails(direction, source, destination, messageID))
 		if appendErr != nil {
-			return "", "", guard.Evaluation{}, audit.Entry{}, errors.Join(ErrRateLimited, appendErr)
+			return "", "", guard.Evaluation{}, audit.Entry{}, errors.Join(err, appendErr)
 		}
-		return "", "", guard.Evaluation{}, failed, ErrRateLimited
+		return "", "", guard.Evaluation{}, failed, err
 	}
 	callCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	stopShutdownCancel := context.AfterFunc(s.lifecycleCtx, cancel)

--- a/internal/mailbox/service_test.go
+++ b/internal/mailbox/service_test.go
@@ -71,7 +71,7 @@ func newEndpoint(t *testing.T, name string, peers map[string]string, evaluator g
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = approvals.Close() })
-	service, err := New(Options{Audit: log, Signer: signer, Peers: peers, Guard: evaluator, Approvals: approvals, Policy: "allow routine coordination only", PolicyVersion: "test-v1", MaxMessageBytes: 4096, Timeout: time.Second, MaxMessageAge: 24 * time.Hour, MaxConcurrent: 1, MaxRequestsPerMinute: maxRequestsPerMinute, MaxGuardCallsPerHour: maxGuardCallsPerHour})
+	service, err := New(Options{Audit: log, Signer: signer, Peers: peers, Guard: evaluator, Approvals: approvals, Policy: "allow routine coordination only", PolicyVersion: "test-v1", DeploymentSHA256: strings.Repeat("a", 64), MaxMessageBytes: 4096, Timeout: time.Second, MaxMessageAge: 24 * time.Hour, MaxConcurrent: 1, MaxRequestsPerMinute: maxRequestsPerMinute, MaxGuardCallsPerHour: maxGuardCallsPerHour})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +399,7 @@ func TestRestartIssuesAcknowledgementForCommittedAcceptance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	reopened, err := New(Options{Audit: reopenedLog, Signer: reopenedSigner, Peers: map[string]string{"work": work.signer.PublicKey()}, Guard: personalGuard, Approvals: reopenedApprovals, Policy: "allow routine coordination only", PolicyVersion: "test-v1", MaxMessageBytes: 4096, Timeout: time.Second, MaxMessageAge: 24 * time.Hour, MaxConcurrent: 1, MaxRequestsPerMinute: maxRequestsPerMinute, MaxGuardCallsPerHour: maxGuardCallsPerHour})
+	reopened, err := New(Options{Audit: reopenedLog, Signer: reopenedSigner, Peers: map[string]string{"work": work.signer.PublicKey()}, Guard: personalGuard, Approvals: reopenedApprovals, Policy: "allow routine coordination only", PolicyVersion: "test-v1", DeploymentSHA256: strings.Repeat("a", 64), MaxMessageBytes: 4096, Timeout: time.Second, MaxMessageAge: 24 * time.Hour, MaxConcurrent: 1, MaxRequestsPerMinute: maxRequestsPerMinute, MaxGuardCallsPerHour: maxGuardCallsPerHour})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcpserver/budget.go
+++ b/internal/mcpserver/budget.go
@@ -16,7 +16,7 @@ func newWindowBudget(limit int, window time.Duration) *windowBudget {
 	return &windowBudget{limit: limit, window: window, used: make([]time.Time, 0, limit)}
 }
 
-func (b *windowBudget) take(now time.Time) bool {
+func (b *windowBudget) Take(now time.Time) (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -33,8 +33,8 @@ func (b *windowBudget) take(now time.Time) bool {
 		b.used = b.used[:0]
 	}
 	if len(b.used) >= b.limit {
-		return false
+		return false, nil
 	}
 	b.used = append(b.used, now)
-	return true
+	return true, nil
 }

--- a/internal/mcpserver/frame_reader_test.go
+++ b/internal/mcpserver/frame_reader_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -178,7 +179,7 @@ func TestRunRejectsInvalidFrameBeforeSDKDecode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			channel := &countingChannel{}
-			err := Run(context.Background(), channel, "test", bytes.NewReader(test.frame), io.Discard, 32, 1, 60)
+			err := Run(context.Background(), channel, "test", bytes.NewReader(test.frame), io.Discard, filepath.Join(t.TempDir(), "state"), 32, 1, 60)
 			if !errors.Is(err, test.want) && (err == nil || !strings.Contains(err.Error(), test.want.Error())) {
 				t.Fatalf("Run error = %v, want %v", err, test.want)
 			}

--- a/internal/mcpserver/request_limit.go
+++ b/internal/mcpserver/request_limit.go
@@ -43,13 +43,17 @@ type requestLimitedStream struct {
 	stopped        bool
 	maxInFlight    int
 	maxOutputBytes int
-	requestBudget  *windowBudget
+	requestBudget  limiter
 	pending        map[jsonrpc.ID]struct{}
 	responding     int
 	nonCalls       int
 	readBuffer     []byte
 	closeErr       error
 	reportError    func(error)
+}
+
+type limiter interface {
+	Take(time.Time) (bool, error)
 }
 
 func newRequestLimitedStream(reader *boundedFrameReadCloser, writer io.WriteCloser, maxInFlight, maxOutputBytes, maxRequestsPerMinute int) *requestLimitedStream {
@@ -164,7 +168,8 @@ func (s *requestLimitedStream) Close() error {
 func (s *requestLimitedStream) admitFrame(frame []byte) ([]byte, []*jsonrpc.Response, error) {
 	// Charge every bounded JSON frame before JSON-RPC decoding. This includes
 	// malformed call-shaped objects that the SDK would reject before dispatch.
-	if !s.requestBudget.take(time.Now()) {
+	allowed, budgetErr := s.requestBudget.Take(time.Now())
+	if budgetErr != nil || !allowed {
 		return nil, nil, errRequestBudgetExhausted
 	}
 	message, decoded, err := decodeJSONRPCFrame(frame)

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/openclaw/turnwire/internal/audit"
+	"github.com/openclaw/turnwire/internal/budget"
 	"github.com/openclaw/turnwire/internal/identity"
 	"github.com/openclaw/turnwire/internal/mailbox"
 )
@@ -161,7 +163,7 @@ func publicToolError(err error) error {
 // validated before the MCP SDK decodes them. If t also implements Shutdown,
 // Run starts that shutdown as soon as transport teardown is observed and waits
 // for both the MCP session and relay workers before returning.
-func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, stdout io.Writer, maxInputBytes, maxConcurrent, maxRequestsPerMinute int) error {
+func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, stdout io.Writer, budgetDir string, maxInputBytes, maxConcurrent, maxRequestsPerMinute int) error {
 	if stdin == nil {
 		return errors.New("MCP input is required")
 	}
@@ -171,6 +173,11 @@ func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, 
 	if maxRequestsPerMinute <= 0 {
 		return errors.New("MCP request budget must be positive")
 	}
+	requestBudget, err := budget.Open(budgetDir, "mcp-frames", maxRequestsPerMinute, time.Minute)
+	if err != nil {
+		return fmt.Errorf("open MCP request budget: %w", err)
+	}
+	defer requestBudget.Close()
 	limit, err := frameByteLimit(maxInputBytes)
 	if err != nil {
 		return fmt.Errorf("configure MCP input limit: %w", err)
@@ -188,6 +195,7 @@ func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, 
 		mailbox.MaxMCPOutputBytes,
 		maxRequestsPerMinute,
 	)
+	stream.requestBudget = requestBudget
 	stream.reportError = transportErrors.Record
 	reader := newTeardownReadCloser(stream)
 	runDone := make(chan struct{})

--- a/internal/securestore/store.go
+++ b/internal/securestore/store.go
@@ -2,6 +2,8 @@
 package securestore
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -98,6 +100,79 @@ func (s *Store) Create(name string, data []byte) error {
 		return fmt.Errorf("sync secure store directory: %w", err)
 	}
 	return nil
+}
+
+// Replace atomically writes and syncs an owner-only value. The destination is
+// selected relative to the already-validated directory descriptor.
+func (s *Store) Replace(name string, data []byte) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	if len(data) == 0 || len(data) > maxFileBytes {
+		return errors.New("secure store value has an invalid size")
+	}
+	var temporaryName string
+	var temporary *os.File
+	for attempt := 0; attempt < 100; attempt++ {
+		var random [12]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return fmt.Errorf("generate secure store temporary name: %w", err)
+		}
+		temporaryName = ".turnwire-" + hex.EncodeToString(random[:]) + ".tmp"
+		file, err := owneronly.OpenAtNoFollow(s.directory, temporaryName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("create secure store temporary value: %w", err)
+		}
+		temporary = file
+		break
+	}
+	if temporary == nil {
+		return errors.New("create secure store temporary value: too many name collisions")
+	}
+	cleanup := true
+	defer func() {
+		_ = temporary.Close()
+		if cleanup {
+			_ = owneronly.UnlinkAt(s.directory, temporaryName)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return fmt.Errorf("secure stored value: %w", err)
+	}
+	if _, err := owneronly.Validate(temporary, owneronly.RegularFile, "secure stored value"); err != nil {
+		return err
+	}
+	if err := writeAll(temporary, data); err != nil {
+		return fmt.Errorf("write secure stored value: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync secure stored value: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close secure stored value: %w", err)
+	}
+	if err := owneronly.RenameAt(s.directory, temporaryName, name); err != nil {
+		return fmt.Errorf("replace secure stored value: %w", err)
+	}
+	cleanup = false
+	if err := s.directory.Sync(); err != nil {
+		return fmt.Errorf("sync secure store directory: %w", err)
+	}
+	return nil
+}
+
+// Delete durably removes one secure value.
+func (s *Store) Delete(name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	if err := owneronly.UnlinkAt(s.directory, name); err != nil {
+		return err
+	}
+	return s.directory.Sync()
 }
 
 // Read reads one validated owner-only file with a fixed memory bound.

--- a/packaging/launchd/org.openclaw.turnwire-tunnel.plist.example
+++ b/packaging/launchd/org.openclaw.turnwire-tunnel.plist.example
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.openclaw.turnwire-tunnel</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/tunnel-client</string>
+    <string>run</string>
+    <string>--profile</string>
+    <string>turnwire</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>/var/tmp/turnwire-tunnel.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>/var/tmp/turnwire-tunnel.stderr.log</string>
+  <key>Umask</key>
+  <integer>63</integer>
+</dict>
+</plist>

--- a/packaging/systemd/turnwire-tunnel.service
+++ b/packaging/systemd/turnwire-tunnel.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Turnwire Secure MCP Tunnel endpoint
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=turnwire
+Group=turnwire
+StateDirectory=turnwire
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/turnwire
+Environment=HOME=/var/lib/turnwire
+Environment=XDG_CONFIG_HOME=/var/lib/turnwire/config
+Environment=XDG_STATE_HOME=/var/lib/turnwire/state
+ExecStart=/usr/local/bin/tunnel-client run --profile turnwire
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- encrypt the complete sensitive audit payload with AES-256-GCM while preserving a verified hash chain
- persist raw MCP, service-request, and guard-call budgets across restarts with fail-closed accounting
- bind executable, build, config, policy, peer set, identity, and deployment measurements into startup events and signed checkpoints
- add crash-recoverable dual-signed identity rotation, revocation bundles, peer rotation/removal, and redacted signed audit exports
- add hardened systemd/launchd tunnel examples and a tag-only release workflow with checksums, CycloneDX SBOMs, and GitHub provenance attestations

## Why

The protocol boundary was strong, but production operation still depended on plaintext local logs, process-local budgets, file-only key lifecycle, and source builds without deployable service/release proof. This closes those gaps without retaining unshipped legacy formats or compatibility paths.

## Security impact

Audit content is encrypted before disk writes; quota/accounting survives restart and clock rollback; key mutation is preceded by a durably published signed recovery certificate and encrypted audit record; checkpoints identify the exact measured deployment; incident response now has an executable kill-switch and evidence-retention sequence.

## Validation

- `go test -race ./...`
- `go test ./...`
- `go vet ./...`
- `go build -trimpath ./cmd/turnwire`
- `actionlint .github/workflows/*.yml`
- local CLI flow: init, checkpoint, redacted export, plaintext scan, identity rotation, log verification
- autoreview: clean after all accepted findings were fixed
