### PR TITLE
ci: stress race detection with a GOMAXPROCS sweep and repeat count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        gomaxprocs: ["2", "8"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,8 +22,14 @@ jobs:
         with:
           go-version: "1.25.x"
           cache: true
-      - run: go test -race ./...
-      - run: go vet ./...
-      - run: go build -trimpath ./cmd/turnwire
-      - if: runner.os == 'Linux'
+      # Re-run the race detector under a GOMAXPROCS sweep and repeat count to
+      # widen the scheduling windows a single default-GOMAXPROCS pass can miss.
+      - run: go test -race -count=5 ./...
+        env:
+          GOMAXPROCS: ${{ matrix.gomaxprocs }}
+      - if: matrix.gomaxprocs == '2'
+        run: go vet ./...
+      - if: matrix.gomaxprocs == '2'
+        run: go build -trimpath ./cmd/turnwire
+      - if: runner.os == 'Linux' && matrix.gomaxprocs == '2'
         run: GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/turnwire


### PR DESCRIPTION
`go test -race ./...` runs once per OS at the default GOMAXPROCS. The race
detector reports only races that actually execute, so a single pass at one
parallelism level can miss scheduling- and timing-dependent races.

This re-runs the race step across a small GOMAXPROCS sweep (`2`, `8`) with
`-count=5`, widening the scheduling windows a single default pass can miss.
`vet` and `build` are pinned to one matrix cell (`gomaxprocs == '2'`) so the
only added CI cost is the race work itself. Native toolchain, no new
dependencies.

## Verification

The updated workflow was run end to end and is green across all four matrix
cells (ubuntu/macos × GOMAXPROCS 2/8):

https://github.com/anagnorisis2peripeteia/turnwire/actions/runs/29409904661

```
test (ubuntu-latest, 2)   success
test (ubuntu-latest, 8)   success
test (macos-latest, 2)    success
test (macos-latest, 8)    success
```

Locally, the exact commands the new job runs stay green alongside the current
baseline:

```
$ go test -race ./...                        exit 0   # current CI (baseline)
$ GOMAXPROCS=2 go test -race -count=5 ./...   exit 0   # new cell
$ GOMAXPROCS=8 go test -race -count=5 ./...   exit 0   # new cell
```

`actionlint` is clean on the modified `.github/workflows/ci.yml`.

---
Review history: https://gist.github.com/anagnorisis2peripeteia/170b5d8fc92db04b8645ffbfd416e386
