### PR TITLE
fix(cli): treat stdout broken pipe as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Treat stdout broken-pipe (EPIPE) as success in CLI output so pipelines like `turnwire version | head` exit cleanly.
 - Rebuild Turnwire as a signed peer mailbox with outbound and inbound GPT-5.4/GPT-5.5 guards, deterministic secret blocking, local hash-bound approvals, delivery acknowledgements, and bilateral audit receipts.
 - Add Ed25519 endpoint identities, trusted-peer configuration, OpenAI request evidence, signed audit checkpoints, and practical Secure MCP Tunnel deployment guidance.
 - Harden the channel with exact returned-model pinning, single-classification verdicts, request and model-call budgets, structured-only byte-bounded MCP output, and JSON-RPC batch rejection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Treat closed stdout pipes as clean CLI pipeline completion, thanks @SebTardif.
+
 ## 0.1.0 - 2026-07-27
 
 - Initial release of Turnwire as a signed peer mailbox with outbound and inbound GPT-5.4/GPT-5.5 guards, deterministic secret blocking, local hash-bound approvals, delivery acknowledgements, and bilateral audit receipts.

--- a/cmd/turnwire/ignore_sigpipe_other.go
+++ b/cmd/turnwire/ignore_sigpipe_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package main
+
+func ignoreBrokenPipeSignal() {}

--- a/cmd/turnwire/ignore_sigpipe_unix.go
+++ b/cmd/turnwire/ignore_sigpipe_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package main
+
+import (
+	"os/signal"
+	"syscall"
+)
+
+// ignoreBrokenPipeSignal prevents SIGPIPE from terminating the process on a
+// closed stdout/stderr pipe so write errors can surface as EPIPE and the CLI
+// can treat broken pipes as clean success.
+func ignoreBrokenPipeSignal() {
+	signal.Ignore(syscall.SIGPIPE)
+}

--- a/cmd/turnwire/main.go
+++ b/cmd/turnwire/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	ignoreBrokenPipeSignal()
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	ctx, stop := signalCancellationContext(context.Background(), signals, func() {

--- a/internal/cli/broken_pipe_other.go
+++ b/internal/cli/broken_pipe_other.go
@@ -1,0 +1,7 @@
+//go:build !unix && !windows
+
+package cli
+
+func isPlatformBrokenPipe(error) bool {
+	return false
+}

--- a/internal/cli/broken_pipe_unix.go
+++ b/internal/cli/broken_pipe_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package cli
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isPlatformBrokenPipe(err error) bool {
+	return errors.Is(err, syscall.EPIPE)
+}

--- a/internal/cli/broken_pipe_unix_test.go
+++ b/internal/cli/broken_pipe_unix_test.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package cli
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestIsPlatformBrokenPipeAcceptsEPIPE(t *testing.T) {
+	t.Parallel()
+	if !isPlatformBrokenPipe(syscall.EPIPE) {
+		t.Fatal("EPIPE was not classified as a broken pipe")
+	}
+}
+
+func TestIsPlatformBrokenPipeRejectsWindowsErrnoOnUnix(t *testing.T) {
+	t.Parallel()
+	if isPlatformBrokenPipe(syscall.Errno(109)) {
+		t.Fatal("Unix errno 109 was classified as a broken pipe")
+	}
+}

--- a/internal/cli/broken_pipe_windows.go
+++ b/internal/cli/broken_pipe_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isPlatformBrokenPipe(err error) bool {
+	var errno syscall.Errno
+	// ERROR_NO_DATA is returned when the reading side of a pipe has closed.
+	return errors.As(err, &errno) && (errno == syscall.ERROR_BROKEN_PIPE || errno == 232)
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"syscall"
 
 	"github.com/openclaw/turnwire/internal/buildinfo"
 )
@@ -175,9 +176,27 @@ func writeRootHelp(w io.Writer) error {
 	return nil
 }
 
+func isBrokenPipe(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		// Windows ERROR_BROKEN_PIPE (109) and ERROR_NO_DATA (232).
+		return errno == 109 || errno == 232
+	}
+	return false
+}
+
 func writeOutput(w io.Writer, data []byte) error {
 	written, err := w.Write(data)
 	if err != nil {
+		if isBrokenPipe(err) {
+			return nil
+		}
 		return err
 	}
 	if written != len(data) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"syscall"
 
 	"github.com/openclaw/turnwire/internal/buildinfo"
 )
@@ -94,6 +93,9 @@ func Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	default:
 		err = usageError("unknown command %q", command)
 	}
+	if isBrokenPipe(err) {
+		return 0
+	}
 	if err == nil {
 		return 0
 	}
@@ -177,18 +179,7 @@ func writeRootHelp(w io.Writer) error {
 }
 
 func isBrokenPipe(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe) {
-		return true
-	}
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
-		// Windows ERROR_BROKEN_PIPE (109) and ERROR_NO_DATA (232).
-		return errno == 109 || errno == 232
-	}
-	return false
+	return errors.Is(err, io.ErrClosedPipe) || isPlatformBrokenPipe(err)
 }
 
 func writeOutput(w io.Writer, data []byte) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -235,18 +234,20 @@ func TestScanLogEntriesFailsWhenRequestedWindowExceedsBudget(t *testing.T) {
 
 var _ io.Writer = failingWriter{}
 
-func TestWriteOutputIgnoresBrokenPipe(t *testing.T) {
+func TestWriteOutputIgnoresClosedPipe(t *testing.T) {
 	t.Parallel()
-	err := writeOutput(brokenPipeWriter{}, []byte("hello\n"))
+	err := writeOutput(errWriter{err: io.ErrClosedPipe}, []byte("hello\n"))
 	if err != nil {
-		t.Fatalf("writeOutput broken pipe: %v", err)
+		t.Fatalf("writeOutput closed pipe: %v", err)
 	}
 }
 
-type brokenPipeWriter struct{}
-
-func (brokenPipeWriter) Write([]byte) (int, error) {
-	return 0, syscall.EPIPE
+func TestRunIgnoresBrokenPipeFromFormattedOutput(t *testing.T) {
+	t.Parallel()
+	var stderr bytes.Buffer
+	if code := Run(context.Background(), []string{"version", "--json"}, &bytes.Buffer{}, errWriter{err: io.ErrClosedPipe}, &stderr); code != 0 {
+		t.Fatalf("Run broken pipe exit = %d, stderr = %q", code, stderr.String())
+	}
 }
 
 func TestWriteOutputPropagatesOtherErrors(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -233,3 +234,32 @@ func TestScanLogEntriesFailsWhenRequestedWindowExceedsBudget(t *testing.T) {
 }
 
 var _ io.Writer = failingWriter{}
+
+func TestWriteOutputIgnoresBrokenPipe(t *testing.T) {
+	t.Parallel()
+	err := writeOutput(brokenPipeWriter{}, []byte("hello\n"))
+	if err != nil {
+		t.Fatalf("writeOutput broken pipe: %v", err)
+	}
+}
+
+type brokenPipeWriter struct{}
+
+func (brokenPipeWriter) Write([]byte) (int, error) {
+	return 0, syscall.EPIPE
+}
+
+func TestWriteOutputPropagatesOtherErrors(t *testing.T) {
+	t.Parallel()
+	want := errors.New("disk full")
+	err := writeOutput(errWriter{err: want}, []byte("hello\n"))
+	if !errors.Is(err, want) {
+		t.Fatalf("writeOutput other error: got %v want %v", err, want)
+	}
+}
+
+type errWriter struct{ err error }
+
+func (w errWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -324,7 +324,9 @@ func runDoctor(ctx context.Context, args []string, opts options, stdout io.Write
 		}
 	} else {
 		for _, check := range report.Checks {
-			fmt.Fprintf(stdout, "%-14s %-4s %s\n", check.Name, strings.ToUpper(check.Status), check.Message)
+			if _, err := fmt.Fprintf(stdout, "%-14s %-4s %s\n", check.Name, strings.ToUpper(check.Status), check.Message); err != nil {
+				return err
+			}
 		}
 	}
 	if !report.OK {


### PR DESCRIPTION
## What Problem This Solves

CLI helpers such as `writeOutput` returned any `Write` error, including `EPIPE` when stdout was closed early (pipelines like `turnwire version | head`). That makes normal pipe truncation look like a hard failure. On Unix, SIGPIPE can also terminate the process before EPIPE is returned unless SIGPIPE is ignored.

## Evidence

### Patch

- Treat `syscall.EPIPE` / closed pipe (and Windows broken-pipe errno values) as success in `writeOutput`.
- Ignore `SIGPIPE` at CLI startup on Unix so the EPIPE path is reachable.
- Unit tests for broken-pipe vs other write errors.

### Live producer status (`PIPESTATUS[0]`, head after SIGPIPE fix)

```console
$ go build -o /tmp/turnwire-bin ./cmd/turnwire
$ bash -c '/tmp/turnwire-bin version | head -n 0; echo producer_exit=${PIPESTATUS[0]} head_exit=${PIPESTATUS[1]}'
producer_exit=0 head_exit=0

$ bash -c '/tmp/turnwire-bin help 2>&1 | head -n 0; echo producer_exit=${PIPESTATUS[0]}'
producer_exit=0

$ go test ./internal/cli/ ./cmd/turnwire/ -count=1
ok
```

Producer exit is 0 (not the pipeline tail alone).

## Real behavior proof

- **Behavior or issue addressed:** stdout broken-pipe / early pipeline close should not fail the CLI process.
- **Real environment tested:** macOS arm64, Go module toolchain, branch `fix/turnwire-audit-2293` after SIGPIPE ignore.
- **Exact steps or command run after this patch:** build binary; `bash -c '… | head -n 0; echo producer_exit=${PIPESTATUS[0]}'`.
- **Evidence after fix:** `producer_exit=0` for version and help pipelines; unit tests pass.
- **Observed result after fix:** SIGPIPE no longer kills the producer; EPIPE classification returns success; shell sees exit 0 from the CLI.
- **What was not tested:** every CLI subcommand (shared `writeOutput` + startup signal policy cover the path).

## Summary

- `isBrokenPipe` + EPIPE success in `writeOutput`
- Unix `signal.Ignore(SIGPIPE)` at startup
- Unit tests + PIPESTATUS producer proof
