### PR TITLE
fix(mcp): bound Shutdown so stuck workers cannot hang exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.2 - Unreleased
 
+- Bound MCP shutdown so a stuck worker cannot hang process exit, thanks @SebTardif.
+
 ## 0.1.1 - 2026-08-01
 
 - Update the MCP Go SDK to 1.7.0 with protocol 2026-07-28 compatibility.

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -244,9 +244,6 @@ func runServeWithGuard(ctx context.Context, args []string, opts options, stdin i
 		fmt.Fprintln(stderr, "turnwire: serving signed mailbox MCP over stdio")
 	}
 	serveErr := mcpserver.Run(ctx, service, buildinfo.Current().Version, stdin, stdout, auditDir, cfg.Limits.MaxMessageBytes, cfg.Limits.MaxConcurrent, cfg.Limits.MaxRequestsPerMinute)
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_ = service.Shutdown(shutdownCtx)
 	if serveErr != nil {
 		if ctx.Err() != nil {
 			return nil

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -244,7 +244,9 @@ func runServeWithGuard(ctx context.Context, args []string, opts options, stdin i
 		fmt.Fprintln(stderr, "turnwire: serving signed mailbox MCP over stdio")
 	}
 	serveErr := mcpserver.Run(ctx, service, buildinfo.Current().Version, stdin, stdout, auditDir, cfg.Limits.MaxMessageBytes, cfg.Limits.MaxConcurrent, cfg.Limits.MaxRequestsPerMinute)
-	_ = service.Shutdown(context.Background())
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = service.Shutdown(shutdownCtx)
 	if serveErr != nil {
 		if ctx.Err() != nil {
 			return nil

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -209,7 +209,9 @@ func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, 
 			case <-reader.Terminated():
 			case <-runDone:
 			}
-			done <- lifecycle.Shutdown(context.WithoutCancel(ctx))
+			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+			defer cancel()
+			done <- lifecycle.Shutdown(shutdownCtx)
 		}()
 	}
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -17,7 +17,10 @@ import (
 	"github.com/openclaw/turnwire/internal/mailbox"
 )
 
-const transportControlHeadroom = 4
+const (
+	transportControlHeadroom = 4
+	shutdownTimeout          = 10 * time.Second
+)
 
 // sdkServerClosingCode is the go-sdk JSON-RPC extension used when a handler
 // finishes after its peer has closed the read side. The SDK does not export
@@ -164,6 +167,24 @@ func publicToolError(err error) error {
 // Run starts that shutdown as soon as transport teardown is observed and waits
 // for both the MCP session and relay workers before returning.
 func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, stdout io.Writer, budgetDir string, maxInputBytes, maxConcurrent, maxRequestsPerMinute int) error {
+	return run(ctx, channel, version, stdin, stdout, budgetDir, maxInputBytes, maxConcurrent, maxRequestsPerMinute, shutdownTimeout)
+}
+
+func run(ctx context.Context, channel Channel, version string, stdin io.Reader, stdout io.Writer, budgetDir string, maxInputBytes, maxConcurrent, maxRequestsPerMinute int, shutdownTimeout time.Duration) (resultErr error) {
+	var shutdown *boundedShutdown
+	if lifecycle, ok := channel.(shutdowner); ok {
+		shutdown = newBoundedShutdown(ctx, lifecycle, shutdownTimeout)
+	}
+	shutdownHandled := false
+	defer func() {
+		if shutdown == nil || shutdownHandled {
+			return
+		}
+		if err := shutdown.wait(); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("shutdown relay: %w", err))
+		}
+	}()
+
 	if stdin == nil {
 		return errors.New("MCP input is required")
 	}
@@ -199,19 +220,14 @@ func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, 
 	stream.reportError = transportErrors.Record
 	reader := newTeardownReadCloser(stream)
 	runDone := make(chan struct{})
-	var shutdownDone <-chan error
-	if lifecycle, ok := channel.(shutdowner); ok {
-		done := make(chan error, 1)
-		shutdownDone = done
+	if shutdown != nil {
 		go func() {
 			select {
 			case <-ctx.Done():
 			case <-reader.Terminated():
 			case <-runDone:
 			}
-			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-			defer cancel()
-			done <- lifecycle.Shutdown(shutdownCtx)
+			shutdown.start()
 		}()
 	}
 
@@ -221,10 +237,52 @@ func Run(ctx context.Context, channel Channel, version string, stdin io.Reader, 
 	})
 	close(runDone)
 	var shutdownErr error
-	if shutdownDone != nil {
-		shutdownErr = <-shutdownDone
+	if shutdown != nil {
+		shutdownErr = shutdown.wait()
+		shutdownHandled = true
 	}
 	return resolveRunError(runErr, shutdownErr, reader.TerminalError(), transportErrors.Err())
+}
+
+type boundedShutdown struct {
+	baseCtx   context.Context
+	lifecycle shutdowner
+	timeout   time.Duration
+	once      sync.Once
+	ctx       context.Context
+	done      chan struct{}
+	err       error
+}
+
+func newBoundedShutdown(ctx context.Context, lifecycle shutdowner, timeout time.Duration) *boundedShutdown {
+	return &boundedShutdown{baseCtx: ctx, lifecycle: lifecycle, timeout: timeout, done: make(chan struct{})}
+}
+
+func (s *boundedShutdown) start() {
+	s.once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(s.baseCtx), s.timeout)
+		s.ctx = ctx
+		go func() {
+			defer cancel()
+			s.err = s.lifecycle.Shutdown(ctx)
+			close(s.done)
+		}()
+	})
+}
+
+func (s *boundedShutdown) wait() error {
+	s.start()
+	select {
+	case <-s.done:
+		return s.err
+	case <-s.ctx.Done():
+		select {
+		case <-s.done:
+			return s.err
+		default:
+			return s.ctx.Err()
+		}
+	}
 }
 
 // resolveRunError normalizes only the SDK's structured server-closing error

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1,8 +1,12 @@
 package mcpserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -31,6 +35,29 @@ func (*stubChannel) Inbox(context.Context, mailbox.InboxInput) (mailbox.InboxOut
 	return mailbox.InboxOutput{}, nil
 }
 func (*stubChannel) Checkpoint() (identity.Checkpoint, error) { return identity.Checkpoint{}, nil }
+
+type stuckShutdownChannel struct {
+	stubChannel
+	release chan struct{}
+}
+
+func (s *stuckShutdownChannel) Shutdown(context.Context) error {
+	<-s.release
+	return nil
+}
+
+func TestRunBoundsStuckShutdown(t *testing.T) {
+	channel := &stuckShutdownChannel{release: make(chan struct{})}
+	defer close(channel.release)
+	started := time.Now()
+	err := run(context.Background(), channel, "test", bytes.NewReader(nil), io.Discard, filepath.Join(t.TempDir(), "state"), 1024, 1, 60, 25*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Run error = %v, want shutdown deadline", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Run took %v, want one bounded shutdown wait", elapsed)
+	}
+}
 
 func TestSignedMailboxToolsOverInMemoryTransport(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## What problem this solves

Turnwire's MCP lifecycle waited on `Shutdown` without a deadline. A relay worker that failed to drain could therefore keep `turnwire serve` from exiting forever.

## Root cause

Transport teardown started relay shutdown under `context.WithoutCancel(ctx)`, which intentionally strips cancellation but previously supplied no replacement deadline. The CLI then called `Shutdown` a second time after the MCP server returned, creating two independent cleanup owners.

## Final change

- Keep shutdown ownership in `internal/mcpserver.Run`.
- Start shutdown on cancellation, input teardown, normal MCP completion, or an early setup failure.
- Stop waiting after one 10-second budget even if a `Shutdown` implementation ignores its context entirely.
- Remove the CLI's second shutdown wait.
- Add regression coverage for a deliberately non-cooperative shutdown implementation.

## Evidence

### Before

A focused reproduction against current `main` failed after 100 ms because `Run` remained blocked on a deadline-free shutdown:

```console
--- FAIL: TestReproUnboundedShutdown (0.10s)
    shutdown_repro_test.go:27: Run remained blocked on Shutdown without a deadline
```

### After

```console
$ go test -race ./...
ok github.com/openclaw/turnwire/internal/mcpserver
ok github.com/openclaw/turnwire/internal/cli
... all packages passed

$ go vet ./...

$ go build -trimpath ./cmd/turnwire
$ GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/turnwire
```

Source-blind built-CLI proof with a fresh initialized endpoint and a closed MCP input pipe:

```console
$ /usr/bin/time -p sh -c 'printf "" | ./turnwire-pr17 ... serve'
real 0.02
```

Real integration proof using the final `mcpserver.Run` with a `Shutdown` implementation that ignores its context forever:

```console
deadline=true elapsed=10.01s error=shutdown relay: context deadline exceeded
```

AutoReview accepted one initial blocker—the first maintainer repair still trusted `Shutdown` to honor cancellation. The final branch independently bounds the wait and the rerun was clean with no accepted/actionable findings.

Validated head: `589a48cb25829c97050c5de1ad8e96d86f2a138d`.

Authenticated guard classification and tunnel transport are unchanged and out of scope for this lifecycle fix.
