### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,217 +1,113 @@
-# Turnwire
+# Turnwire 🔐 — Text crosses. Trust doesn't.
 
-[![CI](https://github.com/openclaw/turnwire/actions/workflows/ci.yml/badge.svg)](https://github.com/openclaw/turnwire/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/openclaw/turnwire/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/openclaw/turnwire/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/openclaw/turnwire?style=flat-square)](https://github.com/openclaw/turnwire/releases/latest)
+[![Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?style=flat-square)](https://go.dev/)
+[![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux-lightgrey?style=flat-square)](#requirements)
+[![License](https://img.shields.io/github/license/openclaw/turnwire?style=flat-square)](LICENSE)
 
-Turnwire is a signed, policy-guarded, text-only channel between two private
-environments. Each environment runs its own local endpoint. An agent carries a
-released envelope through OpenAI to the other endpoint; Turnwire never opens an
-inbound port and never gives OpenAI general host access.
-
-Five MCP tools:
+Turnwire is a signed, policy-guarded MCP channel for moving text between two private environments. Each environment runs a local endpoint that checks, signs, and audits messages without exposing an inbound network service.
 
 ```text
-send_message       guard text, sign a peer-addressed envelope
-receive_message    verify peer signature, guard again, commit to inbox
-confirm_delivery   verify and record the receiver acknowledgement
-list_messages      read accepted messages; every read is audited
-audit_checkpoint   sign the current local audit-chain head
+source endpoint                         destination endpoint
+send_message ── signed envelope ──────▶ receive_message
+confirm_delivery ◀── signed receipt ───
 ```
 
-No files, shell, browser, URL fetch, MCP resources/prompts, or model tools.
+The agent transports released JSON between two independently configured endpoints. Turnwire exposes no file, shell, browser, URL-fetch, resource, prompt, or model tools.
 
-## Practical flow
+## Install
 
-```text
-work agent / OpenAI                                      personal agent / OpenAI
-        |                                                           |
-        | Secure MCP Tunnel                         Secure MCP Tunnel|
-        v                                                           v
- work Turnwire -- local DLP -- GPT guard      GPT guard -- local DLP -- personal Turnwire
-        |                 |                         |                 |
-        |          signed envelope -- agent ------->                 |
-        |                 <---- signed acknowledgement               |
-        v                                                           v
- encrypted work audit                                  encrypted personal audit
-```
-
-1. `send_message` records the proposal locally, runs deterministic secret/DLP
-   checks, then calls the configured GPT guard with strict Structured Outputs.
-2. A denial produces no envelope. A review creates a local pending record;
-   only `turnwire approve MESSAGE_ID` can approve that exact body hash. MCP
-   cannot approve it.
-3. Allowed or locally approved text is signed with the source Ed25519 key. The
-   agent carries the JSON envelope to the peer's `receive_message` tool.
-4. The peer verifies destination, signature, body hash, age, and replay binding,
-   then independently repeats deterministic and GPT guards before committing.
-5. The peer commits the inbox entry, signs that exact audit head in an
-   acknowledgement, then logs receipt issuance. The source verifies and
-   records it with `confirm_delivery`.
-
-OpenAI does not “crawl” either machine. The tunnel client makes an outbound
-HTTPS connection, and OpenAI can call only the exposed MCP tools. Secure MCP
-Tunnel is transport, not generic host-to-host networking.
-
-## Security model
-
-- Default guard: pinned `gpt-5.4-2026-03-05` through Responses.
-- GPT-5.5 supported only as pinned `gpt-5.5-2026-04-23`. Floating model
-  aliases are rejected.
-- Every releasable message gets an outbound model verdict. Every received
-  envelope gets a separate inbound verdict. Errors and malformed output fail
-  closed. The returned model must exactly match the configured snapshot.
-- Obvious credentials and secrets are denied locally before reaching the guard
-  API. GPT is a secondary classifier, not the cryptographic or deterministic
-  boundary.
-- Guard calls set `store: false`, `background: false`, provide no tools, and
-  demand strict JSON Schema output. GPT-5.4 defaults to `in_memory` prompt
-  caching. Current OpenAI docs say GPT-5.5 requires 24-hour extended caching,
-  so init selects `24h` for GPT-5.5.
-- Endpoints trust only configured peer public keys. Envelopes and delivery
-  acknowledgements are Ed25519 signed.
-- Exact text, decisions, policy/model, OpenAI response and `x-request-id`, peer
-  identities, hashes, and receipts enter a synced, AES-GCM-encrypted,
-  hash-chained local log.
-- Every service start records the executable, build, config, policy, peer set,
-  public key, and declared deployment identity. Signed checkpoints bind that
-  deployment digest to the current audit head.
-- MCP emits one structured result, rejects JSON-RPC batches, and caps every
-  input frame and output frame. Inbox reads stop at a fixed encoded-byte cap.
-- Fsynced request, raw-frame, and guard-call budgets survive restarts and clock
-  rollback. Exhaustion or unreadable accounting fails closed.
-
-For strongest OpenAI-side controls, use a dedicated API project approved for
-Zero Data Retention. `store: false` alone does not remove default abuse-
-monitoring retention. See [Data controls](https://developers.openai.com/api/docs/guides/your-data#v1responses).
-
-Secure MCP Tunnel does not emit individual transport requests as Compliance
-Platform app events. Tunnel create/update/delete events appear in Platform
-Audit logs; normal custom-app invocation/auth logging applies separately. See
-the official [logging boundaries](https://developers.openai.com/api/docs/guides/secure-mcp-tunnels#logging-boundaries).
-Turnwire's local ledgers remain the authoritative per-message record.
-
-## Set up two endpoints
-
-Requirements: macOS or Linux, Go 1.25+, and `OPENAI_API_KEY`. Windows runtime
-fails closed until owner-only DACL enforcement exists.
-
-Work machine:
+Install from source:
 
 ```bash
-go build -o ./bin/turnwire ./cmd/turnwire
-./bin/turnwire init --identity work --deployment-id turnwire-work
-./bin/turnwire identity show
+go install github.com/openclaw/turnwire/cmd/turnwire@latest
 ```
 
-Personal machine:
+[GitHub Releases](https://github.com/openclaw/turnwire/releases/latest) also provide checksummed macOS and Linux archives with SBOMs and build attestations. Follow the [release verification steps](docs/deployment.md#install-and-verify) before placing a downloaded binary on your `PATH`.
+
+### Requirements
+
+- macOS or Linux
+- Go 1.25 or newer when building from source
+- An OpenAI API key for guard checks
+
+Windows builds compile, but runtime storage checks fail closed until owner-only DACL enforcement is available.
+
+## Quick start
+
+Create a disposable local endpoint and print its public identity:
 
 ```bash
-go build -o ./bin/turnwire ./cmd/turnwire
-./bin/turnwire init --identity personal --deployment-id turnwire-personal
-./bin/turnwire identity show
+demo_dir="$(mktemp -d)"
+turnwire --config "$demo_dir/config.json" --data-dir "$demo_dir/state" \
+  init --identity work --deployment-id turnwire-work
+turnwire --config "$demo_dir/config.json" --data-dir "$demo_dir/state" identity show
 ```
 
-Exchange only the printed public keys, then pin each peer:
+This creates a local signing key, configuration, and encrypted audit chain. It does not call the guard API; pairing and message transfer require a second endpoint.
 
-```bash
-# work machine
-./bin/turnwire peer add personal PERSONAL_PUBLIC_KEY
+## Pair two endpoints
 
-# personal machine
-./bin/turnwire peer add work WORK_PUBLIC_KEY
-```
+Initialize each endpoint with a stable, distinct identity and deployment ID. Exchange only the public keys printed by `turnwire identity show`, then pin the other endpoint with `turnwire peer add NAME PUBLIC_KEY`.
 
-Verify both:
+Set `OPENAI_API_KEY` on both machines and run `turnwire doctor --probe`. The probe checks local storage, identity and peer configuration, audit integrity, and guard access using fixed non-user text.
 
-```bash
-./bin/turnwire doctor --probe
-```
+The [configuration reference](docs/configuration.md) documents paths, guard policy, supported model snapshots, limits, local approval, and storage requirements.
 
-GPT-5.5 example:
+## Connect an MCP client
 
-```bash
-./bin/turnwire init --identity work --model gpt-5.5-2026-04-23 --force
-```
-
-`--force` preserves the key and audit history but replaces config. Recheck
-policy and peers after a forced init.
-
-## Secure MCP Tunnel
-
-Configure a separate tunnel and custom app per endpoint. The public
-[`tunnel-client`](https://github.com/openai/tunnel-client) can spawn Turnwire:
-
-```bash
-tunnel-client init \
-  --sample sample_mcp_stdio_local \
-  --profile turnwire-work \
-  --tunnel-id TUNNEL_ID \
-  --mcp-command "/absolute/path/to/turnwire/bin/turnwire serve"
-
-tunnel-client doctor --profile turnwire-work --explain
-tunnel-client run --profile turnwire-work
-```
-
-Follow the official [Secure MCP Tunnel guide](https://developers.openai.com/api/docs/guides/secure-mcp-tunnels)
-for permissions and workspace association. Associate a work endpoint with a
-personal workspace only when the work administrator permits that relationship.
-
-Direct local MCP client:
+Turnwire serves MCP over stdio:
 
 ```json
 {
   "mcpServers": {
     "turnwire-work": {
-      "command": "/absolute/path/to/turnwire/bin/turnwire",
+      "command": "/absolute/path/to/turnwire",
       "args": ["serve"]
     }
   }
 }
 ```
 
-## Review and audit
+For hosted clients, run one outbound Secure MCP Tunnel per endpoint. The [deployment and operations runbook](docs/deployment.md) covers tunnel setup, supervision, audit retention, key rotation, and the kill switch.
 
-On `review_required`, approve locally, then retry the identical call:
+## Message flow
 
-```bash
-turnwire approve MESSAGE_ID
-```
+1. `send_message` runs deterministic secret checks and a pinned OpenAI guard. An `allow` verdict releases a peer-addressed Ed25519-signed envelope; `review` requires a hash-bound local CLI approval.
+2. The agent carries the envelope to the configured peer's `receive_message` tool.
+3. The peer verifies the destination, signature, body hash, age, and replay binding, then runs its own deterministic and model guards before committing the message.
+4. The peer signs an acknowledgement over the accepted audit head. The source verifies and records it through `confirm_delivery`.
 
-Audit commands:
+Turnwire does not connect the hosts directly. Secure MCP Tunnel supplies outbound transport; the agent carries the released envelope and acknowledgement between endpoints.
 
-```text
-turnwire log list [--type TYPE] [--limit N] [--json]
-turnwire log show ID [--json]
-turnwire log verify [--json]
-turnwire log export --output AUDIT-METADATA.jsonl
-turnwire checkpoint
-```
+## MCP tools
 
-The export omits message text and model explanations, retains reconciliation
-metadata and chain hashes, and ends with a signed checkpoint. Copy exports and
-periodic checkpoints to immutable storage outside the endpoint. Reconcile
-message IDs, hashes, signed acknowledgements, model/request IDs, deployment
-digests, and available OpenAI custom-app invocation logs.
+| Tool | Purpose |
+| --- | --- |
+| `send_message` | Guard text and return a signed envelope for one configured peer |
+| `receive_message` | Verify and independently guard an envelope, then commit it to the inbox |
+| `confirm_delivery` | Verify and record the receiver's signed acknowledgement |
+| `list_messages` | Read accepted inbox messages; every read is audited |
+| `audit_checkpoint` | Sign the current local audit-chain head for external retention |
 
-## Important limits
+MCP cannot approve a review-required message. The operator must run `turnwire approve MESSAGE_ID` locally, then retry the identical call.
 
-- If GPT inspects plaintext, OpenAI received it. Turnwire controls transfer
-  between environments; it cannot make guard input invisible to OpenAI.
-- A classifier cannot prove text non-confidential. Deterministic checks, narrow
-  policy, local review, signatures, and evidence reduce risk—not guarantee zero
-  leakage.
-- Tunnel authorization controls the app path. Stdio does not expose a verified
-  individual human caller identity; logs identify endpoint and peer.
-- A host administrator can replace binary, keys, policy, approvals, log, or the
-  local audit-encryption key. External checkpoints and exports make later
-  replacement detectable; full-disk encryption still matters.
-- The agent carries released envelopes; Turnwire does not directly connect
-  hosts.
-- Text only. Attachments and arbitrary host access remain out of scope.
+## Security boundaries
 
-Read the [deployment and operations runbook](docs/deployment.md),
-[threat model](docs/threat-model.md), and
-[configuration reference](docs/configuration.md) before deployment.
+- Deterministic rules deny obvious credentials before they reach the guard API.
+- Guard calls use strict Structured Outputs, no tools, `store: false`, `background: false`, and exact returned-model matching. Errors fail closed.
+- Each endpoint independently guards the same text and trusts only configured peer public keys.
+- Sensitive audit fields are AES-GCM-encrypted within a hash-chained local log; signed checkpoints support external reconciliation.
+- Turnwire is a narrow channel, not a sandbox or proof-producing DLP system. OpenAI receives text submitted to the model guard, and classifiers can miss confidential data.
+
+Read the full [threat model](docs/threat-model.md) before deployment. It defines the trust domains, enforced boundaries, OpenAI data boundary, known limitations, and required operational controls.
+
+## Operations
+
+Use `turnwire log list`, `turnwire log show`, and `turnwire log verify` for local inspection. `turnwire log export --output PATH` creates redacted reconciliation metadata, while `turnwire checkpoint` prints a signed audit-head checkpoint for independent storage.
+
+Keep the encrypted audit chain for the endpoint's lifetime because it also carries replay and delivery state. The [operations runbook](docs/deployment.md#audit-and-retention) covers retention, reconciliation, identity rotation, revocation, and recovery.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Rework the README into the house-standard path: pitch, dynamic badges, install, verified quick start, progressive detail, development, and license.
- Cut the front door from 226 to 122 lines while keeping the pairing flow, MCP client example, five-tool surface, and critical trust boundaries.

## Content placement

- Detailed guard configuration, model policy, storage rules, and limits remain in `docs/configuration.md`.
- The expanded security model, OpenAI data boundary, and limitations remain in `docs/threat-model.md`.
- Tunnel setup, audit retention, reconciliation, key rotation, revocation, and recovery remain in `docs/deployment.md`.
- Dropped the obsolete `turnwire log list --type` reference; the current CLI supports `--conversation`, not `--type`.
- No supported behavior or unique current guidance was dropped. No changelog entry was added because this changelog has no docs-only precedent.

## Verification

- `GOBIN=/tmp/turnwire-readme-install go install github.com/openclaw/turnwire/cmd/turnwire@latest` — passed; installed v0.1.1.
- Ran the exact disposable-endpoint quick start with the installed binary — passed; initialization and identity output confirmed.
- Parsed the MCP JSON sample with `jq empty` and syntax-checked the quick-start shell — passed.
- `go test -race ./...`, `go vet ./...`, and `go build ./cmd/turnwire` — passed.
- `GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/turnwire` — passed, confirming the documented build/runtime distinction.
- Checked pairing, probe, approval, log, checkpoint, and serve syntax against the binary's real help. Full paired transfer/probe was not run because it requires two configured endpoints and an OpenAI credential.
- Verified all relative links and anchors; all eight unique external URLs returned HTTP 200; all five Shields SVGs rendered without `invalid` or `not found`.
- Autoreview: clean, no accepted/actionable findings.
