### PR TITLE
build(deps): refresh release tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             mod -json -output "dist/${package}/turnwire.cdx.json"
           tar -C dist -czf "dist/${package}.tar.gz" "${package}"
           rm -rf "dist/${package}"
-      - uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+      - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: dist/*.tar.gz
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.2 - Unreleased
 
 - Bound MCP shutdown so a stuck worker cannot hang process exit, thanks @SebTardif.
+- Refresh the release attestation action and Go tooling dependencies.
 
 ## 0.1.1 - 2026-08-01
 

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.48.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,5 +20,5 @@ golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
-golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
-golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
+golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
+golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=


### PR DESCRIPTION
## Summary

- update `golang.org/x/tools` from 0.42.0 to 0.48.0
- update the pinned `actions/attest` release action from 4.2.0 to 4.2.1
- record the maintenance refresh in the 0.1.2 changelog

The Action SHA is the commit at upstream tag `v4.2.1`. Its patch release updates its archive dependency and fixes OCI tag handling without changing Turnwire's attestation configuration.

## Freshness audit

All direct runtime modules, the CycloneDX release helper, and the other pinned GitHub Actions are already current. `go list -m -u all` still reports three versions referenced only inside dependencies' own module graphs; `go mod tidy` does not retain overrides for those unused packages, so this PR does not add artificial root requirements or SBOM surface.

## Proof

```console
$ go test -race ./...
... all packages passed

$ go vet ./...

$ go build -trimpath ./cmd/turnwire
$ GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/turnwire

$ go mod verify
all modules verified

$ go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.

$ actionlint .github/workflows/*.yml

$ ./turnwire-deps version --json
{"version":"dev","commit":"unknown","build_time":"unknown","go_version":"go1.26.5"}

$ /usr/bin/time -p sh -c 'printf "" | ./turnwire-deps ... serve'
real 0.47

$ go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 mod -json -output turnwire-deps.cdx.json
CycloneDX  1.6  9
```

AutoReview reported no accepted/actionable findings. Public model identifier gate: PASS; the candidate introduces no provider/model identifiers.
