### PR TITLE
ci: enforce Go formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           go-version: "1.25.x"
           cache: true
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            exit 1
+          fi
       - run: go test -race ./...
       - run: go vet ./...
       - run: go build -trimpath ./cmd/turnwire

--- a/internal/guard/live_test.go
+++ b/internal/guard/live_test.go
@@ -27,17 +27,25 @@ func TestLiveOpenAIGuardModels(t *testing.T) {
 				Endpoint: "https://api.openai.com/v1/responses", Model: test.model,
 				APIKeyEnv: "OPENAI_API_KEY", PromptCacheRetention: test.retention,
 			})
-			if err != nil { t.Fatal(err) }
+			if err != nil {
+				t.Fatal(err)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 			result, err := client.Evaluate(ctx, Input{
 				Direction: "outbound", Source: "work", Destination: "personal",
-				Text: "Routine coordination: move tomorrow's meeting to 10:30.",
+				Text:   "Routine coordination: move tomorrow's meeting to 10:30.",
 				Policy: "Allow routine scheduling and coordination without secrets or sensitive data.",
 			})
-			if err != nil { t.Fatal(err) }
-			if result.Model == "" || result.ResponseID == "" || result.ProviderRequestID == "" { t.Fatalf("incomplete provider evidence: %#v", result) }
-			if result.Decision != DecisionAllow && result.Decision != DecisionReview && result.Decision != DecisionDeny { t.Fatalf("invalid decision: %#v", result) }
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Model == "" || result.ResponseID == "" || result.ProviderRequestID == "" {
+				t.Fatalf("incomplete provider evidence: %#v", result)
+			}
+			if result.Decision != DecisionAllow && result.Decision != DecisionReview && result.Decision != DecisionDeny {
+				t.Fatalf("invalid decision: %#v", result)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- enforce gofmt cleanliness in the CI matrix
- format the existing live guard test that exposed the missing gate

## Dependency sweep

- `go get -u ./...` and `go get -u all` produced no manifest or checksum changes
- all pinned GitHub Actions match their latest releases
- `go mod verify` and `govulncheck` completed successfully

## Validation

- `go test -count=1 -race ./...`
- `go vet ./...`
- `go build -trimpath ./cmd/turnwire`
- `GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/turnwire`
- `actionlint`
- built CLI live proof: `turnwire version --json`
- autoreview: clean, no actionable findings
