### PR TITLE
chore(deps): refresh Go tooling and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        go: ["1.25.x", "1.27.x"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25.x"
+          go-version: ${{ matrix.go }}
           cache: true
       - name: Check formatting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.25.x", "1.27.x"]
+        go: ["1.25.x", "1.26.x", "1.27.x"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.25.x"
+          go-version: "1.27.x"
           cache: true
       - name: Build archive and SBOM
         env:
@@ -57,7 +57,7 @@ jobs:
             -ldflags "-s -w -X github.com/openclaw/turnwire/internal/buildinfo.Version=${version} -X github.com/openclaw/turnwire/internal/buildinfo.Commit=${GITHUB_SHA} -X github.com/openclaw/turnwire/internal/buildinfo.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             -o "dist/${package}/turnwire" ./cmd/turnwire
           cp README.md LICENSE "dist/${package}/"
-          go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.10.0 \
+          go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.12.0 \
             mod -json -output "dist/${package}/turnwire.cdx.json"
           tar -C dist -czf "dist/${package}.tar.gz" "${package}"
           rm -rf "dist/${package}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.27.x"
+          # Go 1.26 keeps release binaries compatible with macOS 12.
+          go-version: "1.26.x"
           cache: true
       - name: Build archive and SBOM
         env:

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	golang.org/x/tools v0.48.0 // indirect
+	golang.org/x/tools v0.49.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,5 +20,5 @@ golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
-golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
-golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=


### PR DESCRIPTION
Refresh Go tooling and the release SBOM generator, and validate the source minimum, release toolchain, and latest Go in CI.

| Dependency/tool | Before | After |
| --- | --- | --- |
| `golang.org/x/tools` (MCP SDK test dependency) | v0.48.0 | v0.49.0 |
| `cyclonedx-gomod` release tool | v1.10.0 | v1.12.0 |
| Release Go toolchain | 1.25.x | 1.26.x |
| Ubuntu/macOS CI Go versions | 1.25.x | 1.25.x, 1.26.x, 1.27.x |

`go get -u -t ./...`, the explicit tooling update, and `go mod tidy` regenerated the module files. All other required modules and the six pinned GitHub Actions are current. No module dependencies were added. Modules visible only through unused upstream graph branches were not promoted into direct pins (`go mod why -m` confirms they are unused).

Upstream notes: [x/tools v0.49.0](https://github.com/golang/tools/releases/tag/v0.49.0), [cyclonedx-gomod v1.11.0](https://github.com/CycloneDX/cyclonedx-gomod/releases/tag/v1.11.0), [v1.12.0](https://github.com/CycloneDX/cyclonedx-gomod/releases/tag/v1.12.0). The SBOM tool requires Go 1.26+, while its output remains CycloneDX 1.6. `go.mod` retains the documented Go 1.25 minimum. No application behavior change or changelog entry is needed.

No dependency major upgrades were available. **NEEDS-PETER (non-blocking):** Go 1.27 release binaries would require macOS 13 ([Go release notes](https://go.dev/doc/go1.27#darwin)). This PR retains macOS 12 compatibility using maintained Go 1.26 for releases and validates Go 1.27 in CI. Recommend making the macOS minimum change explicitly in a future release.

Validation on macOS arm64 (all exited 0):

```sh
export GOCACHE="$PWD/.git/deps-refresh/go-cache"
GOTOOLCHAIN=go1.25.14 go test -race ./...
GOTOOLCHAIN=go1.25.14 go vet ./...
GOTOOLCHAIN=go1.25.14 go build -trimpath ./...
GOTOOLCHAIN=go1.26.7 go test -race ./...
GOTOOLCHAIN=go1.26.7 go vet ./...
GOTOOLCHAIN=go1.26.7 go build -trimpath ./...
# Host Go: go1.27.0
go test -race ./...
go vet ./...
go build -trimpath ./...
GOOS=windows GOARCH=amd64 go build -trimpath -o .git/deps-refresh/turnwire.exe ./cmd/turnwire
actionlint .github/workflows/ci.yml .github/workflows/release.yml
go mod verify
```

Race-suite output excerpts:

```text
go version go1.25.14 darwin/arm64
ok  	github.com/openclaw/turnwire/internal/mailbox	14.295s
ok  	github.com/openclaw/turnwire/internal/mcpserver	7.721s
go version go1.26.7 darwin/arm64
ok  	github.com/openclaw/turnwire/internal/mailbox	20.813s
ok  	github.com/openclaw/turnwire/internal/mcpserver	11.075s
go version go1.27.0 darwin/arm64
ok  	github.com/openclaw/turnwire/internal/mailbox	7.125s
ok  	github.com/openclaw/turnwire/internal/mcpserver	3.650s
all modules verified
```

Live proof used the actual built CLI, disposable owner-only state, two generated identities, peer pinning, a real stdio MCP connection, checkpoint signing, an audited inbox read, and audit-chain verification. No remote OpenAI guard calls were made; billable provider tests remain opt-in.

```sh
GOTOOLCHAIN=go1.26.7 go build -trimpath -o .git/deps-refresh/turnwire-go126 ./cmd/turnwire
TURNWIRE_PROOF_BINARY="$PWD/.git/deps-refresh/turnwire-go126" bash .git/deps-refresh/live-proof.sh
```

<details>
<summary>Exact live-proof script</summary>

```sh
#!/bin/bash
set -euo pipefail
binary="${TURNWIRE_PROOF_BINARY:-$PWD/.git/deps-refresh/turnwire}"
demo_dir="$(mktemp -d "$PWD/.git/deps-refresh/live.XXXXXX")"
trap 'rm -rf "$demo_dir"' EXIT
"$binary" --quiet --config "$demo_dir/alice.json" --data-dir "$demo_dir/alice" init --identity alice --deployment-id proof-alice
"$binary" --quiet --config "$demo_dir/bob.json" --data-dir "$demo_dir/bob" init --identity bob --deployment-id proof-bob
alice_public="$("$binary" --config "$demo_dir/alice.json" --data-dir "$demo_dir/alice" identity show --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["public_key"])')"
bob_public="$("$binary" --config "$demo_dir/bob.json" --data-dir "$demo_dir/bob" identity show --json | python3 -c 'import json,sys; print(json.load(sys.stdin)["public_key"])')"
"$binary" --config "$demo_dir/alice.json" --data-dir "$demo_dir/alice" peer add bob "$bob_public"
"$binary" --config "$demo_dir/bob.json" --data-dir "$demo_dir/bob" peer add alice "$alice_public"
python3 - "$binary" "$demo_dir" <<'PY'
import json, selectors, subprocess, sys
binary, root = sys.argv[1:]
p = subprocess.Popen([binary, "--config", root + "/alice.json", "--data-dir", root + "/alice", "serve"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
selector = selectors.DefaultSelector()
selector.register(p.stdout, selectors.EVENT_READ)
def send(value):
    p.stdin.write(json.dumps(value) + "\n")
    p.stdin.flush()
def request(identifier, method, params):
    send({"jsonrpc": "2.0", "id": identifier, "method": method, "params": params})
    assert selector.select(20), "MCP response timed out"
    response = json.loads(p.stdout.readline())
    assert response.get("id") == identifier and "error" not in response, response
    return response["result"]
try:
    result = request(1, "initialize", {"protocolVersion": "2026-07-28", "capabilities": {}, "clientInfo": {"name": "deps-proof", "version": "1"}})
    print("MCP initialize:", result["protocolVersion"], result["serverInfo"]["name"])
    send({"jsonrpc": "2.0", "method": "notifications/initialized"})
    result = request(2, "tools/list", {})
    names = sorted(tool["name"] for tool in result["tools"])
    assert names == ["audit_checkpoint", "confirm_delivery", "list_messages", "receive_message", "send_message"], names
    print("MCP tools:", ", ".join(names))
    result = request(3, "tools/call", {"name": "audit_checkpoint", "arguments": {}})
    assert not result.get("isError"), result
    checkpoint = result["structuredContent"]
    assert checkpoint["signature"] and checkpoint["identity"] == "alice", checkpoint
    print("MCP audit_checkpoint: signed checkpoint for", checkpoint["identity"])
    result = request(4, "tools/call", {"name": "list_messages", "arguments": {}})
    assert not result.get("isError") and not result["structuredContent"]["messages"], result
    print("MCP list_messages: empty inbox, audited read")
    p.stdin.close()
    assert p.wait(timeout=20) == 0, p.stderr.read()
    print("MCP shutdown: exit 0")
finally:
    if p.poll() is None:
        p.kill()
        p.wait()
    selector.close()
PY
"$binary" --config "$demo_dir/alice.json" --data-dir "$demo_dir/alice" log verify
"$binary" --config "$demo_dir/bob.json" --data-dir "$demo_dir/bob" log verify
```

</details>

Actual live output:

```text
Added peer "bob"
Added peer "alice"
MCP initialize: 2025-11-25 turnwire
MCP tools: audit_checkpoint, confirm_delivery, list_messages, receive_message, send_message
MCP audit_checkpoint: signed checkpoint for alice
MCP list_messages: empty inbox, audited read
MCP shutdown: exit 0
Audit verified: 2 entries, head 11a2b2758860f78450e7a209b1c674bbf347280def9d4b747dda759a075ef976
Audit verified: 0 entries, head 
```

Release SBOM integration (exit 0):

```sh
GOTOOLCHAIN=go1.26.7 go run github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.12.0 mod -json -output .git/deps-refresh/turnwire-go126.cdx.json
```

The generated JSON was parsed and every module/version compared with `go list -deps`:

```text
SBOM verified: CycloneDX 1.6, all 9 runtime modules match go list, dependency graph present
```

CI reasoning: default-branch build/test CI was already [green at 036d75e](https://github.com/openclaw/turnwire/actions/runs/31922552810). Every formatting, race-test, vet, native-build, and Windows-cross-build gate is preserved, with a wider toolchain matrix. `Release` is tag-triggered packaging/publication; `ClawSweeper Dispatch` is operational event dispatch; dynamic scheduled/Dependabot jobs are separate from build/test CI. No tag, release, deployment, or production operation was performed. PR checks validate this candidate; the default branch remains unchanged until maintainer review and merge.

Codex autoreview of the final candidate completed scoped-clean with no accepted/actionable findings at the requested default P0 threshold.

Candidate [CI run 33387041790](https://github.com/openclaw/turnwire/actions/runs/33387041790) passed all six Ubuntu/macOS × Go 1.25/1.26/1.27 jobs on `50e6f2e`. [ClawSweeper operational dispatch](https://github.com/openclaw/turnwire/actions/runs/33387042684) also passed. No CI failure or retry was needed.
