### PR TITLE
fix(config): preserve explicit empty and false guard settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.3 - Unreleased
 
+- Preserve explicit empty and false guard settings during config rewrites, including peer updates, so saved settings do not revert to defaults or invalidate GPT-5.5 configurations.
 - Bound default OpenAI guard requests while honoring configured call timeouts, and avoid a panic when DefaultTransport is not *http.Transport, thanks @SebTardif.
 
 ## 0.1.2 - 2026-08-02

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,9 @@ Global `--config PATH` and `--data-dir PATH` overrides precede the command.
 }
 ```
 
-Unknown fields rejected.
+Unknown fields rejected. Omitted fields use their defaults. Explicit empty
+strings and `false` guard settings are preserved when CLI commands rewrite the
+configuration, including peer updates.
 
 ## Identity and peers
 
@@ -112,13 +114,16 @@ evidence, HTTP failure, missing credentials, cancellation, and timeout produce
 no envelope. Deterministic secret rules can deny before the API call.
 
 Default: pinned GPT-5.4 with `in_memory` cache retention. Current OpenAI
-requirements reject `in_memory` for GPT-5.5; use `24h` or omit it. Init selects
+requirements reject `in_memory` for GPT-5.5; use `24h` or set
+`prompt_cache_retention` to `""` to omit it from guard requests. Leaving the
+configuration field out uses the `in_memory` default. Init selects
 `24h` for GPT-5.5. Prefer GPT-5.4 in a dedicated Zero Data Retention project
 when lower cache retention matters. Only `gpt-5.4-2026-03-05` and
 `gpt-5.5-2026-04-23` are accepted; floating aliases are rejected.
 
 `api_key_env` names an existing environment variable. Its value is never
-written or logged. `policy` enters every verdict; increment `policy_version`
+written or logged. Set it to `""` for a loopback test guard that needs no
+authentication. `policy` enters every verdict; increment `policy_version`
 whenever its meaning changes. Callers cannot select model or policy.
 
 ## Local approval

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,15 +67,16 @@ type PeerConfig struct {
 }
 
 // GuardConfig configures the mandatory OpenAI Responses policy classifier.
+// Explicit empty and false values must be encoded because Load overlays defaults.
 type GuardConfig struct {
 	API                  string `json:"api"`
 	Endpoint             string `json:"endpoint"`
 	Model                string `json:"model"`
-	APIKeyEnv            string `json:"api_key_env,omitempty"`
-	AllowRemote          bool   `json:"allow_remote,omitempty"`
+	APIKeyEnv            string `json:"api_key_env"`
+	AllowRemote          bool   `json:"allow_remote"`
 	PolicyVersion        string `json:"policy_version"`
 	Policy               string `json:"policy"`
-	PromptCacheRetention string `json:"prompt_cache_retention,omitempty"`
+	PromptCacheRetention string `json:"prompt_cache_retention"`
 }
 
 // LimitsConfig bounds message size, request duration, and concurrent work.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,3 +117,42 @@ func TestWriteLoadRoundTrip(t *testing.T) {
 		t.Fatalf("loaded = %#v", loaded)
 	}
 }
+
+func TestWriteLoadPreservesExplicitGuardSettings(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*GuardConfig)
+	}{
+		{"empty API key environment", func(guard *GuardConfig) {
+			guard.APIKeyEnv = ""
+		}},
+		{"disabled remote access", func(guard *GuardConfig) {
+			guard.Endpoint = "http://127.0.0.1:8080/v1/responses"
+			guard.AllowRemote = false
+		}},
+		{"empty cache retention", func(guard *GuardConfig) {
+			guard.PromptCacheRetention = ""
+		}},
+		{"GPT-5.5 empty cache retention", func(guard *GuardConfig) {
+			guard.Model = "gpt-5.5-2026-04-23"
+			guard.PromptCacheRetention = ""
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := Default()
+			test.mutate(&cfg.Guard)
+			path := filepath.Join(t.TempDir(), "config.json")
+			if err := Write(path, cfg, false); err != nil {
+				t.Fatal(err)
+			}
+			loaded, err := Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if loaded.Guard != cfg.Guard {
+				t.Fatalf("guard settings changed after saving: got %#v, want %#v", loaded.Guard, cfg.Guard)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Saving an explicitly empty or false guard setting could silently restore a default on the next load. For example, `peer add` removed an empty `api_key_env`, making a keyless loopback guard require the default API-key environment variable. The same path re-enabled `allow_remote` and replaced empty cache retention with `in_memory`, which makes a GPT-5.5 configuration invalid.

Keep those three values explicit in saved configuration JSON. Input defaults and validation stay the same; the configuration docs now distinguish an omitted setting from an explicitly empty value. Add four round-trip regression cases and an Unreleased changelog entry.

Validation:

- All four new regression cases fail against the prior serialization and pass with this fix.
- Full race suites on Go 1.25.0 and 1.27.1, vet, formatting, and a Windows cross-build.
- Built CLI integration with two disposable endpoints and a literal loopback guard: initialization, peer pairing, doctor probes, MCP handshake/tool inventory, signed send/receive/confirmation, inbox, clean shutdown, audit verification, signed checkpoints, and redacted exports. This exercises local guard HTTP traffic; no live OpenAI or tunnel validation is claimed.
- Independent P0–P2 review of the complete change.

The dependency audit found all declared Go dependencies, pinned Actions, and release SBOM tooling current; no dependency changes are included.
